### PR TITLE
chore: re-apply newer changes from suite scripts

### DIFF
--- a/controller/emulator.py
+++ b/controller/emulator.py
@@ -134,14 +134,19 @@ def reset_device():
     reset(client, skip_backup=True, pin_protection=False)
     client.close()
 
-
-def decision():
+def press_yes():
     client = DebugLink(get_device().find_debug())
     client.open()
     time.sleep(SLEEP)
     client.press_yes()
     client.close()
 
+def press_no():
+    client = DebugLink(get_device().find_debug())
+    client.open()
+    time.sleep(SLEEP)
+    client.press_no()
+    client.close()
 
 # enter recovery word or pin
 # enter pin not possible for T2, it is locked, for T1 it is possible

--- a/controller/main.py
+++ b/controller/main.py
@@ -79,9 +79,12 @@ def message_received(client, server, message):
                 cmd.get("needs_backup"),
             )
             response = {"success": True}
-        elif cmdType == "emulator-decision":
-            emulator.decision()
+        elif cmdType == "emulator-press-yes":
+            emulator.press_yes()
             response = {"success": True}
+        elif cmdType == "emulator-press-no":
+            emulator.press_no()
+            response = {"success": True}    
         elif cmdType == "emulator-input":
             emulator.input(cmd["value"])
             response = {"success": True}


### PR DESCRIPTION
there was some refactoring to the scripts inside suite in the meantime. This PR backports this changes here. Suite will then switch to trezor-user-env

resolve #14