### PR TITLE
feat(controller): relaying all the details and warnings to client (POC)

### DIFF
--- a/src/controller.py
+++ b/src/controller.py
@@ -82,8 +82,12 @@ async def handler(websocket, path) -> None:
             elif command == "emulator-start":
                 version = request.get("version") or binaries.FIRMWARES["TT"][0]
                 wipe = request.get("wipe") or False
-                emulator.start(version, wipe)
-                response = {"response": f"Emulator version {version} started"}
+                result = emulator.start(version, wipe)
+                response = {
+                    "response": result.get("response", ""),
+                    "details": result.get("details", []),
+                    "warnings": result.get("warnings", []),
+                }
             elif command == "emulator-stop":
                 emulator.stop()
                 response = {"response": "Emulator stopped"}


### PR DESCRIPTION
Made a quick proof of concept for how to let clients well informed but still satisfy the Cypress tests
- each function called by controller will return three things to it - `response`, `details` and `warnings`
- these things will be relayed to the client, with `success: True` key, as long as there will not be any "real" error