### PR TITLE
fix(controller): removing RuntimeErrors in start functions for bridge and proxy

### DIFF
--- a/src/bridge.py
+++ b/src/bridge.py
@@ -50,7 +50,8 @@ def start(version: str, proxy: bool = False) -> None:
         stop(proxy=proxy)
 
     if proc is not None:
-        raise RuntimeError("Bridge is already running, not spawning a new one")
+        log("WARNING: Bridge is already running, not spawning a new one", "red")
+        return
 
     # normalize path to be relative to this folder, not pwd
     path = os.path.join(os.path.dirname(__file__), "../src/binaries/trezord-go/bin")

--- a/src/bridge_proxy.py
+++ b/src/bridge_proxy.py
@@ -108,7 +108,9 @@ def start() -> None:
     )
     global SERVER
     if SERVER is not None:
-        raise RuntimeError("Bridge proxy is already initialized, cannot be run again")
+        log("WARNING: Bridge proxy is already initialized, cannot be run again", "red")
+        return
+
     SERVER = ThreadingServer((IP, PORT), Handler)
     SERVER.daemon_threads = True
     thread = threading.Thread(target=SERVER.serve_forever)


### PR DESCRIPTION
Fixing problem in #72
- not raising RuntimeError when starting a component, even though it is already running - logging it and returning instead