### PR TITLE
Grdddj/suite ci issues

### DIFF
--- a/src/bridge.py
+++ b/src/bridge.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 import os
 import signal
+import socket
+import time
 from subprocess import Popen
 
 import requests
@@ -8,6 +10,9 @@ from requests.exceptions import ConnectionError
 
 import bridge_proxy
 import helpers
+from bridge_proxy import PORT as BRIDGE_PROXY_PORT
+
+BRIDGE_PORT = 21325
 
 # TODO: consider creating a class from this module to avoid these globals
 proc = None
@@ -38,7 +43,20 @@ def get_status() -> dict:
     return {"is_running": is_running(), "version": version_running}
 
 
+def is_port_in_use(port: int) -> bool:
+    """Checks if a certain port is listening on localhost"""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        return s.connect_ex(("0.0.0.0", port)) == 0
+
+
+def check_bridge_and_proxy_status() -> None:
+    """Reporting the status of bridge and proxy, for debugging purposes"""
+    log(f"Is bridge running - {is_port_in_use(BRIDGE_PORT)}")
+    log(f"Is bridge proxy running - {is_port_in_use(BRIDGE_PROXY_PORT)}")
+
+
 def start(version: str, proxy: bool = False) -> None:
+    log("Starting")
     global proc
     global version_running
 
@@ -65,6 +83,9 @@ def start(version: str, proxy: bool = False) -> None:
     if proxy:
         bridge_proxy.start()
 
+    time.sleep(0.5)
+    check_bridge_and_proxy_status()
+
 
 def stop(proxy: bool = True) -> None:
     log("Stopping")
@@ -80,3 +101,6 @@ def stop(proxy: bool = True) -> None:
 
     if proxy:
         bridge_proxy.stop()
+
+    time.sleep(0.5)
+    check_bridge_and_proxy_status()

--- a/src/bridge_proxy_server.py
+++ b/src/bridge_proxy_server.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+
+"""
+HTTPServer used as proxy for trezord calls from the outside of docker container
+This is workaround for original ip not beeing passed to the container:
+    https://github.com/docker/for-mac/issues/180
+Listening on port 21326 and routes requests to the trezord with changed Origin header
+"""
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from socketserver import ThreadingMixIn
+
+import requests
+
+import helpers
+
+TREZORD_HOST = "0.0.0.0:21325"
+HEADERS = {
+    "Host": TREZORD_HOST,
+    "Origin": "https://user-env.trezor.io",
+}
+IP = "0.0.0.0"
+PORT = 21326
+LOG_COLOR = "green"
+
+
+def log(text: str, color: str = LOG_COLOR) -> None:
+    helpers.log(f"BRIDGE PROXY: {text}", color)
+
+
+# POST request headers override
+# origin is set to the actual machine that made the call not localhost
+def merge_headers(original: dict) -> dict:
+    headers = original.copy()
+    headers.update(HEADERS)
+    return headers
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_HEAD(self) -> None:
+        self.do_GET()
+
+    def do_GET(self) -> None:
+        try:
+            if self.path == "/status/":
+                # read trezord status page
+                url = f"http://{TREZORD_HOST}{self.path}"
+                resp = requests.get(url)
+
+                self.send_response(resp.status_code)
+                self.send_resp_headers(resp)
+                self.wfile.write(resp.content)
+        except Exception as e:
+            self.send_error(404, f"Error trying to proxy: {self.path} Error: {e}")
+
+    def do_POST(self, body: bool = True) -> None:
+        try:
+            url = f"http://{TREZORD_HOST}{self.path}"
+            data_len = int(self.headers.get("content-length", 0))
+            data = self.rfile.read(data_len)
+            headers = merge_headers(dict(self.headers))
+
+            resp = requests.post(url, data=data, headers=headers)
+
+            self.send_response(resp.status_code)
+            self.send_resp_headers(resp)
+            if body:
+                self.wfile.write(resp.content)
+        except Exception as e:
+            self.send_error(404, f"Error trying to proxy: {self.path} Error: {e}")
+
+    def send_resp_headers(self, resp) -> None:
+        # response Access-Control header needs to be exact with original
+        #   request from the caller
+        self.send_header(
+            "Access-Control-Allow-Origin",
+            self.headers.get("Access-Control-Allow-Origin", "*"),
+        )
+
+        # remove Access-Control and Transfer-Encoding headers
+        #   from the original trezord response
+        h = dict(resp.headers)
+        h.pop(
+            "Transfer-Encoding", "chunked"
+        )  # this header returns empty response to the caller (trezor-link)
+        h.pop("Access-Control-Allow-Origin", None)
+        for key, value in h.items():
+            self.send_header(key, value)
+        self.end_headers()
+
+    def log_message(self, format, *args) -> None:
+        """Adds color to make the log clearer."""
+        log(
+            "%s - - [%s] %s\n"
+            % (self.address_string(), self.log_date_time_string(), format % args),
+        )
+
+
+class ThreadingServer(ThreadingMixIn, HTTPServer):
+    pass
+
+
+if __name__ == "__main__":
+    SERVER = ThreadingServer((IP, PORT), Handler)
+    SERVER.serve_forever()


### PR DESCRIPTION
Fixing the issue with failing Suite integration tests (#72)
- the `bridge_proxy` server was previously spawned in a different thread, but even after shutting it down it was still blocking the port, and therefore it was impossible to spawn it again after shutting it down
- solving it by spawning it in a different process, taking the same approach as with `bridge`