### PR TITLE
feat(controller): emulator-apply-settings takes all possible fields

### DIFF
--- a/src/controller.py
+++ b/src/controller.py
@@ -119,10 +119,14 @@ class ResponseGetter:
             emulator.wipe_device()
             return {"response": "Device wiped"}
         elif self.command == "emulator-apply-settings":
-            emulator.apply_settings(
-                self.request_dict["passphrase_always_on_device"],
-            )
-            return {"response": f"Applied setting on emulator {self.request_dict}"}
+            # Relaying all the relevant fields from the request, to make sure
+            #   the client is notified when it sends an unknown field
+            #   and the function will throw an Exception
+            settings_fields = deepcopy(self.request_dict)
+            settings_fields.pop("type", None)
+            settings_fields.pop("id", None)
+            emulator.apply_settings(**settings_fields)
+            return {"response": f"Applied settings on emulator {settings_fields}"}
         elif self.command == "emulator-reset-device":
             emulator.reset_device()
             return {"response": "Device reset"}

--- a/src/emulator.py
+++ b/src/emulator.py
@@ -3,6 +3,7 @@ import signal
 import time
 from pathlib import Path
 from subprocess import PIPE, Popen
+from typing import Optional
 
 from trezorlib import debuglink, device  # type: ignore
 from trezorlib.debuglink import DebugLink  # type: ignore
@@ -271,13 +272,38 @@ def select_num_of_words(num_of_words: int = 12) -> None:
     client.close()
 
 
-def apply_settings(passphrase_always_on_device: bool = False) -> None:
+def apply_settings(
+    language: Optional[str] = None,
+    label: Optional[str] = None,
+    use_passphrase: Optional[bool] = None,
+    homescreen: Optional[str] = None,
+    auto_lock_delay_ms: Optional[int] = None,
+    display_rotation: Optional[int] = None,
+    passphrase_always_on_device: Optional[bool] = None,
+    safety_checks: Optional[int] = None,
+) -> None:
+    """Forwards settings fields to be applied on a device.
+
+    NOTE: does not handle the experimental_features argument,
+      seems that it is not yet supported in latest trezorlib
+    """
+    # Homescreen needs to be bytes object, so if there,
+    #   it should be encoded from the received string
+    homescreen_bytes = homescreen.encode() if homescreen else None
+
     client = TrezorClientDebugLink(get_device())
     client.open()
     time.sleep(SLEEP)
     device.apply_settings(
         client,
+        label=label,
+        language=language,
+        use_passphrase=use_passphrase,
+        homescreen=homescreen_bytes,
         passphrase_always_on_device=passphrase_always_on_device,
+        auto_lock_delay_ms=auto_lock_delay_ms,
+        display_rotation=display_rotation,
+        safety_checks=safety_checks,
     )
     client.close()
 


### PR DESCRIPTION
Addressing issue #54:
- `emulator-apply-settings` command takes all possible fields, so the emulator can be more precisely set up for testing purposes
- when it receives an unsupported field, client will be notified, as we relay all the fields, and an unknown field would cause an Exception

NOTE(s):
- the `homescreen` field is a bytes object, so client should send it decoded as string (to be sent in JSON), and we will encode it into bytes
- the `experimental_features` field is not supported yet, as it seems like the current `trezorlib` version 0.12.2 is not yet compatible with it