### PR TITLE
feat(index): checkbox for starting with wiped/empty device

### DIFF
--- a/src/controller.py
+++ b/src/controller.py
@@ -78,7 +78,10 @@ class ResponseGetter:
             version = self.request_dict.get("version") or binaries.FIRMWARES["TT"][0]
             wipe = self.request_dict.get("wipe") or False
             emulator.start(version, wipe)
-            return {"response": f"Emulator version {version} started"}
+            response_text = f"Emulator version {version} started"
+            if wipe:
+                response_text = response_text + " and wiped to be empty"
+            return {"response": response_text}
         elif self.command == "emulator-stop":
             emulator.stop()
             return {"response": "Emulator stopped"}

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -27,7 +27,7 @@
             <div class="explain-note">
                 You may also check bridge status page on
                 <a href="http://0.0.0.0:21325/status/" target="_blank">
-                    http://0.0.0.0:21325/status/ 
+                    http://0.0.0.0:21325/status/
                 </a>
                 when the bridge is running
             </div>
@@ -49,6 +49,8 @@
             <select id="t2-select"></select>
             <button onclick="emulatorStart('t2-select');">Start</button>
         </div>
+        <input id="wipeDevice" type="checkbox">
+        <label for="wipeDevice">Start with wiped/empty device</label><br>
         <hr />
         <h3>Emulator commands</h3>
         <div class="explain-note">These commands are auto-confirmed using the emulator's debug link.</div><br>
@@ -62,7 +64,7 @@
             <button id="emu-stop" onclick="emulatorStop();">Stop</button>
         </div>
     </section>
-    
+
     <section>
         <h3>Server</h3>
         <textarea id="raw-input" rows="3"></textarea>
@@ -78,7 +80,7 @@
         <h3>Log</h3>
         <div id="log"></div>
     </section>
-    
+
     <script type="text/javascript" src="index.js"></script>
 </body>
 </html>

--- a/src/dashboard/index.js
+++ b/src/dashboard/index.js
@@ -138,9 +138,11 @@ function onCloseClick() {
 
 function emulatorStart(select) {
     const version = document.getElementById(select).value;
+    const wipe = document.getElementById("wipeDevice").checked;
     _send({
         type: 'emulator-start',
         version,
+        wipe,
     });
 }
 


### PR DESCRIPTION
It is beneficial for testing purposes to start with empty device, for example when testing the onboarding process