### PR TITLE
feat(index): current master-build of emulator goes first in dropdown

### DIFF
--- a/src/binaries.py
+++ b/src/binaries.py
@@ -46,8 +46,9 @@ def explore_firmwares(args: Any) -> None:
 
 
 def sort_firmwares(version: str) -> tuple:
+    # Having master version as the first one in the list
     if "master" in version:
-        return 0, 0, 0
+        return 99, 99, 99
     return tuple(int(n) for n in version.split("."))
 
 


### PR DESCRIPTION
As mentioned in #91:
- putting the `master` version of emulator at the top of the dropdown select, to be immediately visible