### PR TITLE
feat(controller): command to click on specified emulator pixel coordination

### DIFF
--- a/docs/controller.md
+++ b/docs/controller.md
@@ -48,6 +48,12 @@
   - **arguments**:
     - **value**: `str`
 
+- **emulator-click**
+  - **action**: click on a specified pixel coordination (x, y) on emulator
+  - **arguments**:
+    - **x**: `int`
+    - **y**: `int`
+
 - **emulator-read-and-confirm-mnemonic**
   - **action**: simulates the Single backup process
 

--- a/src/controller.py
+++ b/src/controller.py
@@ -104,6 +104,11 @@ class ResponseGetter:
             value = self.request_dict["value"]
             emulator.input(value)
             return {"response": f"Input into emulator: {value}"}
+        elif self.command == "emulator-click":
+            x = self.request_dict["x"]
+            y = self.request_dict["y"]
+            emulator.click(x=x, y=y)
+            return {"response": f"Clicked in emulator: x: {x}, y: {y}"}
         elif self.command == "emulator-read-and-confirm-mnemonic":
             emulator.read_and_confirm_mnemonic()
             return {"response": "Read and confirm mnemonic"}

--- a/src/emulator.py
+++ b/src/emulator.py
@@ -208,6 +208,14 @@ def input(value: str) -> None:
     client.close()
 
 
+def click(x: int, y: int) -> None:
+    client = DebugLink(get_device().find_debug())
+    client.open()
+    time.sleep(SLEEP)
+    client.click((x, y))
+    client.close()
+
+
 def swipe(direction: str) -> None:
     client = DebugLink(get_device().find_debug())
     client.open()


### PR DESCRIPTION
Enabling clients to click anywhere on the emulator, based on inputted coordinations
- addressing the issue with [one Suite test](https://github.com/trezor/trezor-suite/blob/e1c710e0c6bbd96b0e7970c15e3650c092aa0c83/packages/integration-tests/projects/suite-web/tests/onboarding/t2-recovery-success.test.ts#L12), where it is somehow impossible to click the `Continue` button in newer emulator versions (bigger than 2.1.4) at the end of successful backup
- (yes, it is kind of hack, we should troubleshoot properly why `pressYes` is not working there, but this `emulator-click` can be used elsewhere as well)