### PR TITLE
fix(ci): update regtest with default wallet and generate blocks

### DIFF
--- a/docker/bitcoin-regtest/entrypoint.sh
+++ b/docker/bitcoin-regtest/entrypoint.sh
@@ -5,10 +5,25 @@ set -e
 cd /opt/coins/nodes/bitcoin_regtest
 
 echo "Starting bitcoin regtest backend service"
-/opt/coins/nodes/bitcoin_regtest/bin/bitcoind -datadir=/opt/coins/data/bitcoin_regtest/backend -conf=/opt/coins/nodes/bitcoin_regtest/bitcoin_regtest.conf &
+bin/bitcoind -datadir=/opt/coins/data/bitcoin_regtest/backend -conf=/opt/coins/nodes/bitcoin_regtest/bitcoin_regtest.conf &
+
+sleep 5
+
+# generate test wallet and blocks
+bin/bitcoin-cli -rpcport=18021 -rpcuser=rpc -rpcpassword=rpc createwallet "tenv-wallet"
+bin/bitcoin-cli -rpcport=18021 -rpcuser=rpc -rpcpassword=rpc -generate 150
+bin/bitcoin-cli -rpcport=18021 -rpcuser=rpc -rpcpassword=rpc settxfee 0.00001
 
 # start blockbook
 cd /opt/coins/blockbook/bitcoin_regtest
 
 echo "Starting blockbook service"
-/opt/coins/blockbook/bitcoin_regtest/bin/blockbook -blockchaincfg=/opt/coins/blockbook/bitcoin_regtest/config/blockchaincfg.json -datadir=/opt/coins/data/bitcoin_regtest/blockbook/db -sync -internal=:19021 -public=:19121 -certfile=/opt/coins/blockbook/bitcoin_regtest/cert/blockbook -explorer= -log_dir=/opt/coins/blockbook/bitcoin_regtest/logs
+bin/blockbook \
+    -blockchaincfg=config/blockchaincfg.json \
+    -datadir=/opt/coins/data/bitcoin_regtest/blockbook/db \
+    -sync \
+    -internal=:19021 \
+    -public=:19121 \
+    -certfile=cert/blockbook \
+    -explorer= \
+    -log_dir=logs


### PR DESCRIPTION
This PR addresses #102 

This seems to be the easiest solution to running the backend and filling it with bitcoins. As we need to wait a bit for the service to start, I had to add sleep, and in general, generating bitcoins will slow down the startup of the blockbook (approx 10-15 seconds) not sure if this could cause some problems with the tenv server @grdddj 