### PR TITLE
Fix/regtest config

### DIFF
--- a/docker/bitcoin-regtest/Dockerfile
+++ b/docker/bitcoin-regtest/Dockerfile
@@ -16,6 +16,8 @@ RUN wget https://github.com/vdovhanych/blockbook/releases/download/v0.3.5/backen
   && rm blockbook-bitcoin-regtest_0.3.5_amd64.deb \
   && rm backend-bitcoin-regtest_0.21.1-satoshilabs-1_amd64.deb
 
+# replace default blockbook config with custom config with changed coin_shortcut to "REGTEST", to be compatibile with trezor-common shorcut.
+COPY ./docker/bitcoin-regtest/blockchaincfg.json /opt/coins/blockbook/bitcoin_regtest/config/blockchaincfg.json
 COPY ./docker/bitcoin-regtest/entrypoint.sh ./entrypoint.sh
 RUN chmod +x ./entrypoint.sh
 

--- a/docker/bitcoin-regtest/blockchaincfg.json
+++ b/docker/bitcoin-regtest/blockchaincfg.json
@@ -1,0 +1,20 @@
+{
+    "coin_name": "Regtest",
+    "coin_shortcut": "REGTEST",
+    "coin_label": "Regtest",
+    "rpc_url": "http://127.0.0.1:18021",
+    "rpc_user": "rpc",
+    "rpc_pass": "rpc",
+    "rpc_timeout": 25,
+    "parse": true,
+    "message_queue_binding": "tcp://127.0.0.1:48321",
+    "subversion": "",
+    "address_format": "",
+    "xpub_magic": 70617039,
+    "xpub_magic_segwit_p2sh": 71979618,
+    "xpub_magic_segwit_native": 73342198,
+    "slip44": 1,
+    "mempool_workers": 8,
+    "mempool_sub_workers": 2,
+    "block_addresses_to_keep": 300
+}

--- a/docker/bitcoin-regtest/entrypoint.sh
+++ b/docker/bitcoin-regtest/entrypoint.sh
@@ -19,11 +19,11 @@ cd /opt/coins/blockbook/bitcoin_regtest
 
 echo "Starting blockbook service"
 bin/blockbook \
-    -blockchaincfg=config/blockchaincfg.json \
+    -blockchaincfg=/opt/coins/blockbook/bitcoin_regtest/config/blockchaincfg.json \
     -datadir=/opt/coins/data/bitcoin_regtest/blockbook/db \
     -sync \
     -internal=:19021 \
     -public=:19121 \
-    -certfile=cert/blockbook \
     -explorer= \
-    -log_dir=logs
+    -log_dir=/opt/coins/blockbook/bitcoin_regtest/logs \
+    -dbcache=0


### PR DESCRIPTION
- use blockbook custom config. coin_shortcut: `REGTEST` instead of `rBTC`, compatible with[ trezor-common](https://github.com/trezor/trezor-common/blob/master/defs/bitcoin/bitcoin_regtest.json#L3)

- disable unnecessary https in blockbook service, now its served at `http://127.0.0.1:19121/`