### PR TITLE
arm and m1 apple silicon support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ For a future use you can omit the second step and run `up` (the third step) dire
 
 ### MacOS
 
-*Supported on Intel Mac devices (ARM Mac's are not supported for now)*
+*Supported on Intel and ARM Mac devices (Regtest is not supported on ARM Mac device)*
 
 #### Prerequisites
 
@@ -75,7 +75,7 @@ You need:
 
 Download these as you are used to. We recommend using `nix` or `brew`, but that's your fight.
 
-#### Run it
+#### Run it on Intel Mac
 
 1. Run XQuartz and leave it running on the background. Wait till it is launched.
 2. In XQuartz settings go to Preferences > Security and enable "Allow connections from network clients".
@@ -86,9 +86,17 @@ Download these as you are used to. We recommend using `nix` or `brew`, but that'
 7. Run it: `docker-compose -f ./docker/compose.yml up trezor-user-env-mac trezor-user-env-regtest` [^1]
 8. Open http://localhost:9002.
 
+#### Run it on ARM Mac
+
+1. Follow steps 1-5 above for Intel Mac.
+2. Download the latest docker build: `docker-compose -f ./docker/compose.yml pull trezor-user-env-mac-arm`.
+3. Run it: `docker-compose -f ./docker/compose.yml up trezor-user-env-mac-arm`.
+4. Open http://localhost:9002.
+
 For a future use you can omit the second step and run `up` (the third step) directly. **However, you will not have the latest master builds then!**
 
 [^1]: If you get an error with `trezor-user-env-regtest` starting up, you will need to clean container contents by pruning that container or all stopped containers with `docker container prune`
+
 ----
 
 ### Windows

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -34,6 +34,39 @@ build and push test image:
     - docker push $CONTAINER_NAME:$CI_COMMIT_SHA
     - docker push $CONTAINER_NAME:test
 
+# trezor-user-env arm docker images build
+.build_arm: &build_arm
+  image: $CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX/docker
+  variables:
+    CONTAINER_NAME_ARM: "$CI_REGISTRY/satoshilabs/trezor/trezor-user-env/trezor-user-env-arm"
+  services:
+    - docker:dind
+  before_script:
+    - docker login $CI_REGISTRY -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD
+
+build and push arm image:
+  stage: build
+  <<: *build_arm
+  only:
+    - master
+    - vdovhanych/m1-support
+  script:
+    - docker build --tag $CONTAINER_NAME_ARM:latest  -f docker/arm/Dockerfile .
+    - docker push $CONTAINER_NAME_ARM:latest
+
+build and push arm test image:
+  stage: build
+  <<: *build
+  except:
+    - schedules
+    - master
+    - /^run\//
+  script:
+    # note that this way "test" tag gets overwritten everytime
+    - docker build --tag $CONTAINER_NAME_ARM:$CI_COMMIT_SHA --tag $CONTAINER_NAME_ARM:test -f docker/arm/Dockerfile .
+    - docker push $CONTAINER_NAME_ARM:$CI_COMMIT_SHA
+    - docker push $CONTAINER_NAME_ARM:test
+
 # regtest docker images build
 .build_regtest: &build_regtest
   image: $CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX/docker

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -36,20 +36,20 @@ build and push test image:
 
 # trezor-user-env arm docker images build
 .build_arm: &build_arm
-  image: $CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX/docker
   variables:
     CONTAINER_NAME_ARM: "$CI_REGISTRY/satoshilabs/trezor/trezor-user-env/trezor-user-env-arm"
-  services:
-    - docker:dind
   before_script:
     - docker login $CI_REGISTRY -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD
+  tags:
+    - darwin_arm
 
 build and push arm image:
   stage: build
   <<: *build_arm
   only:
+    - schedules  # nightly build
     - master
-    - vdovhanych/m1-support
+    - /^run\//
   script:
     - docker build --tag $CONTAINER_NAME_ARM:latest  -f docker/arm/Dockerfile .
     - docker push $CONTAINER_NAME_ARM:latest
@@ -57,15 +57,14 @@ build and push arm image:
 build and push arm test image:
   stage: build
   <<: *build
+  when: manual
   except:
     - schedules
     - master
     - /^run\//
   script:
-    # note that this way "test" tag gets overwritten everytime
-    - docker build --tag $CONTAINER_NAME_ARM:$CI_COMMIT_SHA --tag $CONTAINER_NAME_ARM:test -f docker/arm/Dockerfile .
-    - docker push $CONTAINER_NAME_ARM:$CI_COMMIT_SHA
-    - docker push $CONTAINER_NAME_ARM:test
+    - docker build  --tag $CONTAINER_NAME_ARM:CI_COMMIT_BRANCH-test -f docker/arm/Dockerfile .
+    - docker push $CONTAINER_NAME_ARM:CI_COMMIT_BRANCH-test
 
 # regtest docker images build
 .build_regtest: &build_regtest

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -54,18 +54,6 @@ build and push arm image:
     - docker build --tag $CONTAINER_NAME_ARM:latest  -f docker/arm/Dockerfile .
     - docker push $CONTAINER_NAME_ARM:latest
 
-build and push arm test image:
-  stage: build
-  <<: *build
-  when: manual
-  except:
-    - schedules
-    - master
-    - /^run\//
-  script:
-    - docker build  --tag $CONTAINER_NAME_ARM:CI_COMMIT_BRANCH-test -f docker/arm/Dockerfile .
-    - docker push $CONTAINER_NAME_ARM:CI_COMMIT_BRANCH-test
-
 # regtest docker images build
 .build_regtest: &build_regtest
   image: $CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX/docker

--- a/docker/arm/Dockerfile
+++ b/docker/arm/Dockerfile
@@ -1,9 +1,5 @@
 FROM vdovhanych/nixos
 
-# "fake" dbus address to prevent errors
-# https://github.com/SeleniumHQ/docker-selenium/issues/87
-#ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
-
 # good colors for most applications
 ENV TERM xterm
 

--- a/docker/arm/Dockerfile
+++ b/docker/arm/Dockerfile
@@ -1,0 +1,34 @@
+FROM vdovhanych/nixos
+
+# "fake" dbus address to prevent errors
+# https://github.com/SeleniumHQ/docker-selenium/issues/87
+#ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+
+# good colors for most applications
+ENV TERM xterm
+
+# trezor emu
+ENV XDG_RUNTIME_DIR "/var/tmp"
+
+# trezorctl https://click.palletsprojects.com/en/7.x/python3/
+ENV LC_ALL C.UTF-8
+ENV LANG C.UTF-8
+
+# copy python websocket server and all binaries
+COPY ./ ./trezor-user-env
+
+WORKDIR ./trezor-user-env
+
+RUN ls /
+RUN ls /trezor-user-env
+
+RUN nix-shell --run "./src/binaries/firmware/bin/download.sh"
+RUN nix-shell --run "./src/binaries/trezord-go/bin/download.sh"
+
+RUN nix-shell --run "./docker/create_version_file.sh"
+
+RUN rm -rf /var/tmp/trezor.flash
+
+RUN nix-shell --run "echo deps pre-installed"
+
+CMD nix-shell --run './run.sh'

--- a/docker/arm/Dockerfile
+++ b/docker/arm/Dockerfile
@@ -22,6 +22,9 @@ WORKDIR ./trezor-user-env
 RUN ls /
 RUN ls /trezor-user-env
 
+# updates the nix-channel to have latest changes
+RUN nix-channel --update
+
 RUN nix-shell --run "./src/binaries/firmware/bin/download.sh"
 RUN nix-shell --run "./src/binaries/trezord-go/bin/download.sh"
 
@@ -30,5 +33,7 @@ RUN nix-shell --run "./docker/create_version_file.sh"
 RUN rm -rf /var/tmp/trezor.flash
 
 RUN nix-shell --run "echo deps pre-installed"
+
+RUN nix-shell --run "poetry install"
 
 CMD nix-shell --run './run.sh'

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -18,6 +18,17 @@ services:
     environment:
       - DISPLAY=docker.for.mac.host.internal:0
 
+  trezor-user-env-mac-arm:
+    container_name: trezor-user-env.arm
+    image: registry.gitlab.com/satoshilabs/trezor/trezor-user-env/trezor-user-env-arm
+    ports:
+      - "9001:9001"
+      - "9002:9002"
+      - "21326:21326"
+      - "127.0.0.1:21325:21326" # macos needs proxy to override the "origin" of the trezord request
+    environment:
+      - DISPLAY=docker.for.mac.host.internal:0
+
   trezor-user-env-regtest:
     container_name: trezor-user-env-regtest
     image: registry.gitlab.com/satoshilabs/trezor/trezor-user-env/trezor-user-env-regtest

--- a/src/binaries.py
+++ b/src/binaries.py
@@ -54,6 +54,7 @@ def sort_firmwares(version: str) -> tuple:
 
 def explore_bridges() -> None:
     BRIDGES.append("2.0.31")
+    BRIDGES.append("2.0.31-arm64")
     BRIDGES.append("2.0.27")
     BRIDGES.append("2.0.26")
     BRIDGES.append("2.0.19")

--- a/src/binaries/firmware/bin/download.sh
+++ b/src/binaries/firmware/bin/download.sh
@@ -3,7 +3,9 @@ set -e -o pipefail
 
 SITE="https://firmware.corp.sldev.cz/releases/emulators/"
 CORE_LATEST_BUILD="https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/artifacts/master/download?job=core%20unix%20frozen%20debug%20build"
+CORE_LATEST_ARM_BUILD="https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/artifacts/master/download?job=core%20unix%20frozen%20debug%20build%20arm"
 LEGACY_LATEST_BUILD="https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/artifacts/master/download?job=legacy%20emu%20regular%20debug%20build"
+LEGACY_LATEST_ARM_BUILD="https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/artifacts/master/download?job=legacy%20emu%20regular%20debug%20build%20arm"
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
 BIN_DIR=$(pwd)
@@ -14,6 +16,7 @@ if ! wget --no-config -e robots=off --no-verbose --no-clobber --no-parent --cut-
   echo "You will have only available latest builds from CI"
   echo
 fi
+
 
 # download emulator from master
 TMP_DIR="$BIN_DIR/tmp"
@@ -32,9 +35,17 @@ wget --no-config -O trezor-emu-core-master.zip "$CORE_LATEST_BUILD"
 unzip -q trezor-emu-core-master.zip
 mv core/build/unix/trezor-emu-core ../trezor-emu-core-v2-master
 
+ wget --no-config -O trezor-emu-core-arm-master.zip "$CORE_LATEST_ARM_BUILD"
+ unzip -q trezor-emu-core-arm-master.zip -d arm/
+ mv arm/core/build/unix/trezor-emu-core-arm ../trezor-emu-core-v2-master-arm
+
 wget --no-config -O trezor-emu-legacy-master.zip "$LEGACY_LATEST_BUILD"
 unzip -q trezor-emu-legacy-master.zip
 mv legacy/firmware/trezor.elf ../trezor-emu-legacy-v1-master
+
+wget --no-config -O trezor-emu-legacy-arm-master.zip "$LEGACY_LATEST_ARM_BUILD"
+unzip -q trezor-emu-legacy-arm-master.zip -d arm/
+mv arm/legacy/firmware/trezor-arm.elf ../trezor-emu-legacy-v1-master-arm
 
 cd "$BIN_DIR"
 

--- a/src/binaries/trezord-go/bin/download.sh
+++ b/src/binaries/trezord-go/bin/download.sh
@@ -5,4 +5,4 @@ set -e
 
 # Bridge needs an older glibc so we are pinning to nixos-21.05 (stable) as of 2021-07-02
 nix-shell -p autoPatchelfHook -I "nixpkgs=https://github.com/NixOS/nixpkgs/archive/e9148dc1c30e02aae80cc52f68ceb37b772066f3.tar.gz" --run "autoPatchelf trezord-*"
-nix-shell -p autoPatchelfHook --run "patchelf --set-interpreter /nix/store/34k9b4lsmr7mcmykvbmwjazydwnfkckk-glibc-2.33-50/lib/ld-linux-aarch64.so.1 ./src/binaries/trezord-go/bin/*-arm64"
+nix-shell -p autoPatchelfHook  --run "patchelf --set-interpreter /nix/store/0y64vbl8hc0xqq5ag6wwj5r3pr0l6z2s-glibc-2.33-56/lib/ld-linux-aarch64.so.1 ./src/binaries/trezord-go/bin/*-arm64"

--- a/src/binaries/trezord-go/bin/download.sh
+++ b/src/binaries/trezord-go/bin/download.sh
@@ -5,3 +5,4 @@ set -e
 
 # Bridge needs an older glibc so we are pinning to nixos-21.05 (stable) as of 2021-07-02
 nix-shell -p autoPatchelfHook -I "nixpkgs=https://github.com/NixOS/nixpkgs/archive/e9148dc1c30e02aae80cc52f68ceb37b772066f3.tar.gz" --run "autoPatchelf trezord-*"
+nix-shell -p autoPatchelfHook --run "patchelf --set-interpreter /nix/store/34k9b4lsmr7mcmykvbmwjazydwnfkckk-glibc-2.33-50/lib/ld-linux-aarch64.so.1 ./src/binaries/trezord-go/bin/*-arm64"

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -19,6 +19,7 @@
         <div>
             <i>Start Bridge with emulator support.</i><br>
             <button onclick="bridgeStart('2.0.31')">Start 2.0.31</button>
+            <button onclick="bridgeStart('2.0.31-arm64')">Start 2.0.31-arm64</button>
             <button onclick="bridgeStop()">Stop</button>
             <button onclick="bridgeStart('2.0.27')">Start 2.0.27</button>
             <input id="bridgeUseLogfile" type="checkbox">


### PR DESCRIPTION
This introduces support for M1 or any other arm device that supports docker. This pr is still a draft since there need to be some more changes. 

TODO: 

- [x] Add arm device in our CI for building the emulator 
- [x] Add arm device in our CI for building arm Docker image. Alternatively, set it up with `docker buildx`
- [x] Change firmware script to fetch latest arm emulator build from CI
