### PR TITLE
chore(nix): updating channel before we patch emulator files

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,9 @@ WORKDIR ./trezor-user-env
 RUN ls /
 RUN ls /trezor-user-env
 
+# updates the nix-channel to have latest changes
+RUN nix-channel --update
+
 RUN nix-shell --run "./src/binaries/firmware/bin/download.sh"
 RUN nix-shell --run "./src/binaries/trezord-go/bin/download.sh"
 


### PR DESCRIPTION
This should fix launching the latest master version emulator. The problem was with different GCC lib versions and simple nix-channel update fixed that as we already were using unstable channel in the base docker image of tenv. 
fixes #116 