### PR TITLE
feat(emulator): allowing to download and run emulator from URL

### DIFF
--- a/docs/controller.md
+++ b/docs/controller.md
@@ -27,8 +27,15 @@
   - **action**: start the specified version of emulator (and if one already runs, kills it)
   - **arguments**:
     - **version**: `str` (1.9.4, 2.4.0., etc.) - default is the latest TT
-    - **wipe**: `bool` ... whether to delete the emulator profile before starting it - default is False
+    - **wipe**: `bool` whether to delete the emulator profile before starting it - default is False
     - **output_to_logfile**: `bool` whether the debug output should go to a logfile - default is True - otherwise it goes to stdout
+
+- **emulator-start-from-url**
+  - **action**: downloads emulator from specified URL and runs it
+  - **arguments**:
+    - **url**: `str` from where to download the emulator
+    - **model**: `str` which emulator it is - either "1" for T1 or "2" for T2
+    - **wipe**: `bool` whether to delete the emulator profile before starting it - default is False
 
 - **emulator-stop**
   - **action**: stop the emulator

--- a/src/binaries.py
+++ b/src/binaries.py
@@ -46,8 +46,8 @@ def explore_firmwares(args: Any) -> None:
 
 
 def sort_firmwares(version: str) -> tuple:
-    # Having master version as the first one in the list
-    if "master" in version:
+    # Having master and url versions as the first one in the list
+    if "master" in version or "url" in version:
         return 99, 99, 99
     return tuple(int(n) for n in version.split("."))
 

--- a/src/controller.py
+++ b/src/controller.py
@@ -110,13 +110,13 @@ class ResponseGetter:
             )
             response_text = f"Bridge version {version} started"
             if BRIDGE_PROXY:
-                response_text = response_text + " with bridge proxy"
+                response_text += " with bridge proxy"
             return {"response": response_text}
         elif self.command == "bridge-stop":
             bridge.stop(proxy=BRIDGE_PROXY)
             response_text = "Stopping bridge"
             if BRIDGE_PROXY:
-                response_text = response_text + " + stopping bridge proxy"
+                response_text += " + stopping bridge proxy"
             return {"response": response_text}
         else:
             return {
@@ -132,7 +132,17 @@ class ResponseGetter:
             emulator.start(version, wipe, output_to_logfile)
             response_text = f"Emulator version {version} started"
             if wipe:
-                response_text = response_text + " and wiped to be empty"
+                response_text += " and wiped to be empty"
+            return {"response": response_text}
+        elif self.command == "emulator-start-from-url":
+            url = self.request_dict["url"]
+            model = self.request_dict["model"]
+            wipe = self.request_dict.get("wipe", False)
+            output_to_logfile = self.request_dict.get("output_to_logfile", True)
+            emulator.start_from_url(url, model, wipe, output_to_logfile)
+            response_text = f"Emulator downloaded from {url} and started"
+            if wipe:
+                response_text += " and wiped to be empty"
             return {"response": response_text}
         elif self.command == "emulator-stop":
             emulator.stop()

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -38,24 +38,40 @@
 
     <section>
         <h3>Emulator</h3>
-        <div class="explain-note">Use left and right arrow keys to emulate the Trezor One buttons. Mouse clicks for Trezor T.</div><br>
-        <div id="emu-status-line"><b>Status: <span id="emu-status">unknown</span></b></div>
+        <div class="explain-note">
+            Use left and right arrow keys to emulate the Trezor One buttons. Mouse clicks for Trezor T.
+        </div>
+
+        <br>
+
+        <div id="emu-status-line">
+            <b>Status: <span id="emu-status">unknown</span></b>
+        </div>
         <div>
             <h4>Trezor One</h4>
             <select id="t1-select"></select>
             <button onclick="emulatorStart('t1-select');">Start</button>
-            <br />
         </div>
         <div>
             <h4>Trezor T</h4>
             <select id="t2-select"></select>
             <button onclick="emulatorStart('t2-select');">Start</button>
         </div>
-        <input id="wipeDevice" type="checkbox">
-        <label for="wipeDevice">Start with wiped/empty device</label><br>
-        <input id="emulatorUseLogfile" type="checkbox">
-        <label for="emulatorUseLogfile">Logs into logfile</label><br>
-        <hr />
+        <div>
+            <input id="wipeDevice" type="checkbox">
+            <label for="wipeDevice">Start with wiped/empty device</label>
+            <input id="emulatorUseLogfile" type="checkbox">
+            <label for="emulatorUseLogfile">Logs into logfile</label><br>
+        </div>
+        <div>
+            <input id="emu-url" type="text" placeholder="Full emulator URL, link to Gitlab job or just job ID - as specified in select. Do not forget to specify model (T1/T2)" style="width:50%;"/>
+            <select id="emu-url-format-select"></select>
+            <select id="emu-url-model-select"></select>
+            <button onclick="emulatorStartFromUrl();">Start from URL</button>
+        </div>
+
+        <hr>
+
         <h3>Emulator commands</h3>
         <div class="explain-note">These commands are auto-confirmed using the emulator's debug link.</div><br>
         <div>

--- a/src/dashboard/index.js
+++ b/src/dashboard/index.js
@@ -148,6 +148,53 @@ function emulatorStart(select) {
     });
 }
 
+function emulatorStartFromUrl() {
+    let url = document.getElementById("emu-url").value;
+    if (!url) {
+        alert("URL is empty!");
+        return
+    }
+
+    // Taking the last character - "1" or "2" from the model
+    const model = document.getElementById("emu-url-model-select").value.substr(-1);
+    const urlFormat = document.getElementById("emu-url-format-select").value;
+    const wipe = document.getElementById("wipeDevice").checked;
+    const output_to_logfile = document.getElementById("emulatorUseLogfile").checked;
+
+    const gitlabJobPrefix = "https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs"
+    const T1PathSuffix = "artifacts/raw/legacy/firmware/trezor.elf"
+    const T2PathSuffix = "artifacts/raw/core/build/unix/trezor-emu-core"
+
+    // URL might need some processing in case it is not complete
+    // (Yes, handling URLs as strings is not very good, but should be alright in this easy case)
+    if (urlFormat === "Gitlab job link") {
+        // Getting rid of possible slash at the end
+        if (url.substr(-1) === "/") {
+            url = url.slice(0, -1);
+        }
+
+        if (model === "1") {
+            url = `${url}/${T1PathSuffix}`
+        } else {
+            url = `${url}/${T2PathSuffix}`
+        }
+    } else if (urlFormat === "Gitlab job ID") {
+        if (model === "1") {
+            url = `${gitlabJobPrefix}/${url}/${T1PathSuffix}`
+        } else {
+            url = `${gitlabJobPrefix}/${url}/${T2PathSuffix}`
+        }
+    }
+
+    _send({
+        type: 'emulator-start-from-url',
+        url,
+        model,
+        wipe,
+        output_to_logfile,
+    });
+}
+
 function emulatorWipe() {
     _send({
         type: 'emulator-wipe',
@@ -292,4 +339,13 @@ window.onload = function () {
     init();
     watchBackgroundStatus();
     document.getElementById('raw-input').value = templateJSON;
+
+    const t1orT2Select = document.getElementById('emu-url-model-select');
+    createOption(t1orT2Select, "T2")
+    createOption(t1orT2Select, "T1")
+
+    const urlFormatSelect = document.getElementById('emu-url-format-select');
+    createOption(urlFormatSelect, "Gitlab job link")
+    createOption(urlFormatSelect, "Gitlab job ID")
+    createOption(urlFormatSelect, "Custom link")
 };


### PR DESCRIPTION
Connected with https://github.com/trezor/trezor-firmware/issues/1932 and https://github.com/trezor/trezor-user-env/issues/49

Ability to specify emulator URL which will be downloaded and run by `tenv`.

Tested using emulators from `Gitlab CI` - 
https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/1839236800/artifacts/raw/core/build/unix/trezor-emu-core
https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/1839236825/artifacts/raw/legacy/firmware/trezor.elf