### PR TITLE
redirecting debug logs from emulator and bridge into a logfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ emulator.img
 .mypy_cache
 docker/version.txt
 logs/debugging.log
+logs/emulator_bridge.log

--- a/docs/controller.md
+++ b/docs/controller.md
@@ -28,6 +28,7 @@
   - **arguments**:
     - **version**: `str` (1.9.4, 2.4.0., etc.) - default is the latest TT
     - **wipe**: `bool` ... whether to delete the emulator profile before starting it - default is False
+    - **output_to_logfile**: `bool` whether the debug output should go to a logfile - default is True - otherwise it goes to stdout
 
 - **emulator-stop**
   - **action**: stop the emulator
@@ -104,6 +105,7 @@
   - **action**: start the specified version of bridge (only if it is not already running)
   - **arguments**:
     - **version**: `str` (2.0.27, 2.0.31, etc.) - defaults to the latest available one
+    - **output_to_logfile**: `bool` whether the debug output should go to a logfile - default is True - otherwise it goes to stdout
 
 - **bridge-stop**
   - **action**: stop the bridge

--- a/src/bridge.py
+++ b/src/bridge.py
@@ -42,7 +42,7 @@ def check_bridge_and_proxy_status() -> None:
     log(f"Is bridge proxy running - {is_port_in_use(BRIDGE_PROXY_PORT)}")
 
 
-def start(version: str, proxy: bool = False) -> None:
+def start(version: str, proxy: bool = False, output_to_logfile: bool = True) -> None:
     log("Starting")
     global proc
     global version_running
@@ -63,7 +63,15 @@ def start(version: str, proxy: bool = False) -> None:
 
     command = f"{path}/trezord-go-v{version} -ed 21324:21325 -u=false"
 
-    proc = Popen(command, shell=True, preexec_fn=os.setsid)
+    if output_to_logfile:
+        # Conditionally redirecting the output to a logfile instead of terminal/stdout
+        log_file = open(helpers.EMU_BRIDGE_LOG, "a")
+        log(f"All the bridge debug output redirected to {helpers.EMU_BRIDGE_LOG}")
+        proc = Popen(
+            command, shell=True, preexec_fn=os.setsid, stdout=log_file, stderr=log_file
+        )
+    else:
+        proc = Popen(command, shell=True, preexec_fn=os.setsid)
 
     version_running = version
 

--- a/src/controller.py
+++ b/src/controller.py
@@ -103,7 +103,7 @@ class ResponseGetter:
 
     def run_bridge_command(self) -> dict:
         if self.command == "bridge-start":
-            version = self.request_dict.get("version") or binaries.BRIDGES[0]
+            version = self.request_dict.get("version", binaries.BRIDGES[0])
             output_to_logfile = self.request_dict.get("output_to_logfile", True)
             bridge.start(
                 version, proxy=BRIDGE_PROXY, output_to_logfile=output_to_logfile
@@ -126,8 +126,8 @@ class ResponseGetter:
 
     def run_emulator_command(self) -> dict:
         if self.command == "emulator-start":
-            version = self.request_dict.get("version") or binaries.FIRMWARES["TT"][0]
-            wipe = self.request_dict.get("wipe") or False
+            version = self.request_dict.get("version", binaries.FIRMWARES["TT"][0])
+            wipe = self.request_dict.get("wipe", False)
             output_to_logfile = self.request_dict.get("output_to_logfile", True)
             emulator.start(version, wipe, output_to_logfile)
             response_text = f"Emulator version {version} started"
@@ -143,7 +143,7 @@ class ResponseGetter:
                 self.request_dict["pin"],
                 self.request_dict["passphrase_protection"],
                 self.request_dict["label"],
-                self.request_dict.get("needs_backup") or False,
+                self.request_dict.get("needs_backup", False),
             )
             return {"response": f"Emulator set up - {self.request_dict}"}
         elif self.command == "emulator-press-yes":
@@ -165,8 +165,8 @@ class ResponseGetter:
             emulator.read_and_confirm_mnemonic()
             return {"response": "Read and confirm mnemonic"}
         elif self.command == "emulator-read-and-confirm-shamir-mnemonic":
-            shares = self.request_dict.get("shares") or 1
-            threshold = self.request_dict.get("threshold") or 1
+            shares = self.request_dict.get("shares", 1)
+            threshold = self.request_dict.get("threshold", 1)
             emulator.read_and_confirm_shamir_mnemonic(
                 shares=shares, threshold=threshold
             )
@@ -208,7 +208,7 @@ class ResponseGetter:
     def run_regtest_command(self) -> dict:
         if self.command == "regtest-mine-blocks":
             block_amount = self.request_dict["block_amount"]
-            address = self.request_dict.get("address") or REGTEST_RPC.getnewaddress()
+            address = self.request_dict.get("address", REGTEST_RPC.getnewaddress())
             REGTEST_RPC.generatetoaddress(block_amount, address)
             return {"response": f"Mined {block_amount} blocks by address {address}"}
         elif self.command == "regtest-send-to-address":

--- a/src/controller.py
+++ b/src/controller.py
@@ -104,7 +104,10 @@ class ResponseGetter:
     def run_bridge_command(self) -> dict:
         if self.command == "bridge-start":
             version = self.request_dict.get("version") or binaries.BRIDGES[0]
-            bridge.start(version, proxy=BRIDGE_PROXY)
+            output_to_logfile = self.request_dict.get("output_to_logfile", True)
+            bridge.start(
+                version, proxy=BRIDGE_PROXY, output_to_logfile=output_to_logfile
+            )
             response_text = f"Bridge version {version} started"
             if BRIDGE_PROXY:
                 response_text = response_text + " with bridge proxy"
@@ -125,7 +128,8 @@ class ResponseGetter:
         if self.command == "emulator-start":
             version = self.request_dict.get("version") or binaries.FIRMWARES["TT"][0]
             wipe = self.request_dict.get("wipe") or False
-            emulator.start(version, wipe)
+            output_to_logfile = self.request_dict.get("output_to_logfile", True)
+            emulator.start(version, wipe, output_to_logfile)
             response_text = f"Emulator version {version} started"
             if wipe:
                 response_text = response_text + " and wiped to be empty"

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -21,6 +21,8 @@
             <button onclick="bridgeStart('2.0.31')">Start 2.0.31</button>
             <button onclick="bridgeStop()">Stop</button>
             <button onclick="bridgeStart('2.0.27')">Start 2.0.27</button>
+            <input id="bridgeUseLogfile" type="checkbox">
+            <label for="bridgeUseLogfile">Logs into logfile</label><br>
         </div>
         <div>
             <div id="bridge-status-line"><b>Status: <span id="bridge-status">unknown</span></b></div>
@@ -51,6 +53,8 @@
         </div>
         <input id="wipeDevice" type="checkbox">
         <label for="wipeDevice">Start with wiped/empty device</label><br>
+        <input id="emulatorUseLogfile" type="checkbox">
+        <label for="emulatorUseLogfile">Logs into logfile</label><br>
         <hr />
         <h3>Emulator commands</h3>
         <div class="explain-note">These commands are auto-confirmed using the emulator's debug link.</div><br>

--- a/src/dashboard/index.js
+++ b/src/dashboard/index.js
@@ -139,10 +139,12 @@ function onCloseClick() {
 function emulatorStart(select) {
     const version = document.getElementById(select).value;
     const wipe = document.getElementById("wipeDevice").checked;
+    const output_to_logfile = document.getElementById("emulatorUseLogfile").checked;
     _send({
         type: 'emulator-start',
         version,
         wipe,
+        output_to_logfile,
     });
 }
 
@@ -188,9 +190,11 @@ function emulatorStop() {
 }
 
 function bridgeStart(version) {
+    const output_to_logfile = document.getElementById("bridgeUseLogfile").checked;
     _send({
         type: 'bridge-start',
         version,
+        output_to_logfile,
     });
 }
 

--- a/src/emulator.py
+++ b/src/emulator.py
@@ -85,7 +85,7 @@ def get_status() -> dict:
     return {"is_running": is_running(), "version": version_running}
 
 
-def start(version: str, wipe: bool) -> None:
+def start(version: str, wipe: bool, output_to_logfile: bool = True) -> None:
     global proc
     global version_running
 
@@ -123,7 +123,19 @@ def start(version: str, wipe: bool) -> None:
         # - run T1 emulator
         # - run T1 & T2 emulator at once
         # - run two T2/T1 emulators
-        proc = Popen(command, shell=True, preexec_fn=os.setsid)
+        if output_to_logfile:
+            # Conditionally redirecting the output to a logfile instead of terminal/stdout
+            log_file = open(helpers.EMU_BRIDGE_LOG, "a")
+            log(f"All the emulator debug output redirected to {helpers.EMU_BRIDGE_LOG}")
+            proc = Popen(
+                command,
+                shell=True,
+                preexec_fn=os.setsid,
+                stdout=log_file,
+                stderr=log_file,
+            )
+        else:
+            proc = Popen(command, shell=True, preexec_fn=os.setsid)
         log(f"the commandline is {str(proc.args)}")
         version_running = version
 

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -12,6 +12,8 @@ if not os.path.exists(LOG_DIR):
     os.mkdir(LOG_DIR)
 
 LOG_FILENAME = str(LOG_DIR / "debugging.log")
+EMU_BRIDGE_LOG = str(LOG_DIR / "emulator_bridge.log")
+
 
 logging.basicConfig(
     filename=LOG_FILENAME,


### PR DESCRIPTION
Connected with issues in https://github.com/trezor/trezor-firmware/pull/1972 with enormous log in `Gitlab` disabling us from seeing the final result of `Connect` tests and discussion with @matejcik 

Sending all the output from `emulator` and `bridge` into `logs/emulator_bridge.log`.

We could make this conditional on some parameter sent into `bridge.start()` and `emulator.start()` functions