### PR TITLE
chore(emulator): better handling of allow_unsafe

### DIFF
--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -59,9 +59,12 @@
             <input id="seed-input" type="text" placeholder="default seed: all all" />
             <button onclick="emulatorSetup();">Load seed</button>
             <button onclick="emulatorResetDevice();">Reset</button>
+            <button onclick="emulatorStop();">Stop</button>
+        </div>
+        <div>
             <button onclick="emulatorPressYes();">Press yes</button>
             <button onclick="emulatorPressNo();">Press no</button>
-            <button id="emu-stop" onclick="emulatorStop();">Stop</button>
+            <button onclick="emulatorAllowUnsafe();">Allow unsafe (safety checks)</button>
         </div>
         <div>
             <button onclick="readAndConfirmMnemonic();">Read and confirm mnemonic</button>

--- a/src/dashboard/index.js
+++ b/src/dashboard/index.js
@@ -181,6 +181,12 @@ function emulatorPressNo() {
     });
 }
 
+function emulatorAllowUnsafe() {
+    _send({
+        type: 'emulator-allow-unsafe-paths',
+    });
+}
+
 function emulatorStop() {
     _send({
         type: 'emulator-stop',

--- a/src/emulator.py
+++ b/src/emulator.py
@@ -431,7 +431,7 @@ def allow_unsafe() -> None:
     client.open()
     time.sleep(SLEEP)
 
-    # Each model has its own supported safety checks level
+    # T1 does not support PromptAlways
     if client.features.major_version == 1:
         safety_checks = messages.SafetyCheckLevel.PromptTemporarily
     else:


### PR DESCRIPTION
Coming from discussion with @matejcik in https://github.com/trezor/trezor-firmware/pull/1972#issuecomment-987813473

When calling `allow_unsafe`, catching the possible error of not being able to apply it. The benefit is that any caller of `tenv` (like `connect` in our case) will not have to care about not calling it for lower versions not supporting safety checks.

Additionally we could check that the error message contains either `Unsupported safety-checks setting` (case for `T1`) or `No setting provided` (case for older `T2`). (Not to catch for example `Device is not initialized` when trying to allow checks on fresh device)

@matejcik from when does `T1` support safety checks (and does it really)? I am getting the errors even on `1.10.2`, which is relatively new