### PR TITLE
chore(tests): basic tests for controller commands

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: "Controller tests"
+
+on: [pull_request]
+
+
+jobs:
+  controller_test:
+    runs-on: ubuntu-latest
+    env:
+      SDL_VIDEODRIVER: "dummy"
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - name: Setup Nix
+        uses: cachix/install-nix-action@v13
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Download emulator and bridge binaries
+        run: nix-shell --run "./src/binaries/firmware/bin/download.sh && ./src/binaries/trezord-go/bin/download.sh"
+      - name: "Install poetry"
+        run: nix-shell --run "poetry install"
+      - name: Run the tests
+        run: nix-shell --run "poetry run make test"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,8 +4,10 @@ variables:
 
 stages:
   - prebuild
+  - test
   - build
 
 include:
   - ci/prebuild.yml
+  - ci/test.yml
   - ci/build.yml

--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,9 @@ code_check:
 	@mypy .
 	@echo [FLAKE8]
 	@flake8 .
+
+test:
+	pytest -s
+
+test_with_running_controller:
+	pytest -s --controller-already-runs

--- a/ci/test.yml
+++ b/ci/test.yml
@@ -1,0 +1,20 @@
+image: $CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX/nixos/nix:2.3.12
+
+test:
+  stage: test
+  needs: []
+  variables:
+    SDL_VIDEODRIVER: "dummy"
+  script:
+    - nix-shell --run "./src/binaries/firmware/bin/download.sh && ./src/binaries/trezord-go/bin/download.sh"
+    - nix-shell --run "poetry install"
+    - nix-shell --run "poetry run make test"
+  after_script:
+    - cp /builds/satoshilabs/trezor/trezor-user-env/logs/debugging.log trezor-user-env-debugging.log
+    - cp /builds/satoshilabs/trezor/trezor-user-env/logs/emulator_bridge.log tenv-emulator-bridge-debugging.log
+  artifacts:
+    paths:
+      - trezor-user-env-debugging.log
+      - tenv-emulator-bridge-debugging.log
+    expire_in: 1 week
+    when: always

--- a/docs/controller.md
+++ b/docs/controller.md
@@ -110,6 +110,9 @@
 
 - **emulator-reset-device**
   - **action**: reset the device
+  - **arguments**:
+    - **use_shamir**: `bool` (optional) - whether to use Shamir backup (SLIP39) - default is False (BIP39 will be used)
+
 
 - **emulator-get-screenshot**
   - **action**: get current screen encoded as base64

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,4 +1,26 @@
 [[package]]
+name = "atomicwrites"
+version = "1.4.0"
+description = "Atomic file writes."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "attrs"
+version = "21.4.0"
+description = "Classes Without Boilerplate"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.extras]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
+
+[[package]]
 name = "black"
 version = "21.12b0"
 description = "The uncompromising code formatter."
@@ -110,6 +132,14 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "iniconfig"
+version = "1.1.1"
+description = "iniconfig: brain-dead simple config-ini parsing"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "isort"
 version = "5.10.1"
 description = "A Python utility / library to sort Python imports."
@@ -173,6 +203,17 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "packaging"
+version = "21.3"
+description = "Core utilities for Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
+
+[[package]]
 name = "pathspec"
 version = "0.9.0"
 description = "Utility library for gitignore style pattern matching of file paths."
@@ -193,6 +234,37 @@ docs = ["Sphinx (>=4)", "furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-
 test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
 
 [[package]]
+name = "pluggy"
+version = "1.0.0"
+description = "plugin and hook calling mechanisms for python"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "psutil"
+version = "5.8.0"
+description = "Cross-platform lib for process and system monitoring in Python."
+category = "main"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.extras]
+test = ["ipaddress", "mock", "unittest2", "enum34", "pywin32", "wmi"]
+
+[[package]]
+name = "py"
+version = "1.11.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
 name = "pycodestyle"
 version = "2.8.0"
 description = "Python style guide checker"
@@ -207,6 +279,52 @@ description = "passive checker of Python programs"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pyparsing"
+version = "3.0.6"
+description = "Python parsing module"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
+
+[[package]]
+name = "pytest"
+version = "6.2.5"
+description = "pytest: simple powerful testing with Python"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
+attrs = ">=19.2.0"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<2.0"
+py = ">=1.8.2"
+toml = "*"
+
+[package.extras]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.16.0"
+description = "Pytest support for asyncio."
+category = "main"
+optional = false
+python-versions = ">= 3.6"
+
+[package.dependencies]
+pytest = ">=5.4.0"
+
+[package.extras]
+testing = ["coverage", "hypothesis (>=5.7.1)"]
 
 [[package]]
 name = "requests"
@@ -246,7 +364,7 @@ python-versions = "*"
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -315,9 +433,17 @@ python-versions = ">=3.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "ec2f184f7655bde67ec4fcc39b4d3c90439c0d15d1882c94b8bb5faf8fbef8f8"
+content-hash = "a716b600f25033763cb66b02114fa50773046c00160b1fcb4c886f892d5efc8f"
 
 [metadata.files]
+atomicwrites = [
+    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
+    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
+]
+attrs = [
+    {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
+    {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
+]
 black = [
     {file = "black-21.12b0-py3-none-any.whl", hash = "sha256:a615e69ae185e08fdd73e4715e260e2479c861b5740057fde6e8b4e3b7dd589f"},
     {file = "black-21.12b0.tar.gz", hash = "sha256:77b80f693a569e2e527958459634f18df9b0ba2625ba4e0c2d5da5be42e6f2b3"},
@@ -352,6 +478,10 @@ flake8 = [
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
+]
+iniconfig = [
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
+    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 isort = [
     {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
@@ -400,6 +530,10 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
+packaging = [
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
+]
 pathspec = [
     {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
     {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
@@ -408,6 +542,44 @@ platformdirs = [
     {file = "platformdirs-2.4.0-py3-none-any.whl", hash = "sha256:8868bbe3c3c80d42f20156f22e7131d2fb321f5bc86a2a345375c6481a67021d"},
     {file = "platformdirs-2.4.0.tar.gz", hash = "sha256:367a5e80b3d04d2428ffa76d33f124cf11e8fff2acdaa9b43d545f5c7d661ef2"},
 ]
+pluggy = [
+    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
+    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
+psutil = [
+    {file = "psutil-5.8.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:0066a82f7b1b37d334e68697faba68e5ad5e858279fd6351c8ca6024e8d6ba64"},
+    {file = "psutil-5.8.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:0ae6f386d8d297177fd288be6e8d1afc05966878704dad9847719650e44fc49c"},
+    {file = "psutil-5.8.0-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:12d844996d6c2b1d3881cfa6fa201fd635971869a9da945cf6756105af73d2df"},
+    {file = "psutil-5.8.0-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:02b8292609b1f7fcb34173b25e48d0da8667bc85f81d7476584d889c6e0f2131"},
+    {file = "psutil-5.8.0-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:6ffe81843131ee0ffa02c317186ed1e759a145267d54fdef1bc4ea5f5931ab60"},
+    {file = "psutil-5.8.0-cp27-none-win32.whl", hash = "sha256:ea313bb02e5e25224e518e4352af4bf5e062755160f77e4b1767dd5ccb65f876"},
+    {file = "psutil-5.8.0-cp27-none-win_amd64.whl", hash = "sha256:5da29e394bdedd9144c7331192e20c1f79283fb03b06e6abd3a8ae45ffecee65"},
+    {file = "psutil-5.8.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:74fb2557d1430fff18ff0d72613c5ca30c45cdbfcddd6a5773e9fc1fe9364be8"},
+    {file = "psutil-5.8.0-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:74f2d0be88db96ada78756cb3a3e1b107ce8ab79f65aa885f76d7664e56928f6"},
+    {file = "psutil-5.8.0-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:99de3e8739258b3c3e8669cb9757c9a861b2a25ad0955f8e53ac662d66de61ac"},
+    {file = "psutil-5.8.0-cp36-cp36m-win32.whl", hash = "sha256:36b3b6c9e2a34b7d7fbae330a85bf72c30b1c827a4366a07443fc4b6270449e2"},
+    {file = "psutil-5.8.0-cp36-cp36m-win_amd64.whl", hash = "sha256:52de075468cd394ac98c66f9ca33b2f54ae1d9bff1ef6b67a212ee8f639ec06d"},
+    {file = "psutil-5.8.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c6a5fd10ce6b6344e616cf01cc5b849fa8103fbb5ba507b6b2dee4c11e84c935"},
+    {file = "psutil-5.8.0-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:61f05864b42fedc0771d6d8e49c35f07efd209ade09a5afe6a5059e7bb7bf83d"},
+    {file = "psutil-5.8.0-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:0dd4465a039d343925cdc29023bb6960ccf4e74a65ad53e768403746a9207023"},
+    {file = "psutil-5.8.0-cp37-cp37m-win32.whl", hash = "sha256:1bff0d07e76114ec24ee32e7f7f8d0c4b0514b3fae93e3d2aaafd65d22502394"},
+    {file = "psutil-5.8.0-cp37-cp37m-win_amd64.whl", hash = "sha256:fcc01e900c1d7bee2a37e5d6e4f9194760a93597c97fee89c4ae51701de03563"},
+    {file = "psutil-5.8.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6223d07a1ae93f86451d0198a0c361032c4c93ebd4bf6d25e2fb3edfad9571ef"},
+    {file = "psutil-5.8.0-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:d225cd8319aa1d3c85bf195c4e07d17d3cd68636b8fc97e6cf198f782f99af28"},
+    {file = "psutil-5.8.0-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:28ff7c95293ae74bf1ca1a79e8805fcde005c18a122ca983abf676ea3466362b"},
+    {file = "psutil-5.8.0-cp38-cp38-win32.whl", hash = "sha256:ce8b867423291cb65cfc6d9c4955ee9bfc1e21fe03bb50e177f2b957f1c2469d"},
+    {file = "psutil-5.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:90f31c34d25b1b3ed6c40cdd34ff122b1887a825297c017e4cbd6796dd8b672d"},
+    {file = "psutil-5.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6323d5d845c2785efb20aded4726636546b26d3b577aded22492908f7c1bdda7"},
+    {file = "psutil-5.8.0-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:245b5509968ac0bd179287d91210cd3f37add77dad385ef238b275bad35fa1c4"},
+    {file = "psutil-5.8.0-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:90d4091c2d30ddd0a03e0b97e6a33a48628469b99585e2ad6bf21f17423b112b"},
+    {file = "psutil-5.8.0-cp39-cp39-win32.whl", hash = "sha256:ea372bcc129394485824ae3e3ddabe67dc0b118d262c568b4d2602a7070afdb0"},
+    {file = "psutil-5.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:f4634b033faf0d968bb9220dd1c793b897ab7f1189956e1aa9eae752527127d3"},
+    {file = "psutil-5.8.0.tar.gz", hash = "sha256:0c9ccb99ab76025f2f0bbecf341d4656e9c1351db8cc8a03ccd62e318ab4b5c6"},
+]
+py = [
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
+]
 pycodestyle = [
     {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
     {file = "pycodestyle-2.8.0.tar.gz", hash = "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"},
@@ -415,6 +587,18 @@ pycodestyle = [
 pyflakes = [
     {file = "pyflakes-2.4.0-py2.py3-none-any.whl", hash = "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"},
     {file = "pyflakes-2.4.0.tar.gz", hash = "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c"},
+]
+pyparsing = [
+    {file = "pyparsing-3.0.6-py3-none-any.whl", hash = "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4"},
+    {file = "pyparsing-3.0.6.tar.gz", hash = "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"},
+]
+pytest = [
+    {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
+    {file = "pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89"},
+]
+pytest-asyncio = [
+    {file = "pytest-asyncio-0.16.0.tar.gz", hash = "sha256:7496c5977ce88c34379df64a66459fe395cd05543f0a2f837016e7144391fcfb"},
+    {file = "pytest_asyncio-0.16.0-py3-none-any.whl", hash = "sha256:5f2a21273c47b331ae6aa5b36087047b4899e40f03f18397c0e65fa5cca54e9b"},
 ]
 requests = [
     {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,12 +9,15 @@ python = "^3.9"
 termcolor = "^1.1.0"
 trezor = "^0.13.0"
 websockets = "^10.1"
+psutil = "^5.8.0"
 
 [tool.poetry.dev-dependencies]
 black = "^21.12b0"
 isort = "^5.10.1"
 mypy = "^0.910"
 flake8 = "^4.0.1"
+pytest = "^6.2.5"
+pytest-asyncio = "^0.16.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,8 @@
 ignore =
     # E501: line too long
     E501,
+    # I900: import not listed as a requirement
+    I900,
 
 [isort]
 multi_line_output = 3

--- a/src/controller.py
+++ b/src/controller.py
@@ -214,7 +214,8 @@ class ResponseGetter:
         elif self.command == "emulator-reset-device":
             emulator.reset_device(
                 self.request_dict.get("backup_type", messages.BackupType.Bip39),
-                self.request_dict.get("strength"),
+                self.request_dict.get("strength", 128),
+                use_shamir=self.request_dict.get("use_shamir", False),
             )
             return {"response": "Device reset"}
         elif self.command == "emulator-get-screenshot":

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -86,6 +86,7 @@
             <input id="seed-input" type="text" placeholder="default seed: all all" />
             <button onclick="emulatorSetup();">Load seed</button>
             <button onclick="emulatorResetDevice();">Reset</button>
+            <button onclick="emulatorResetDeviceShamir();">Reset with Shamir</button>
             <button onclick="emulatorStop();">Stop</button>
         </div>
         <div>

--- a/src/dashboard/index.js
+++ b/src/dashboard/index.js
@@ -216,6 +216,13 @@ function emulatorResetDevice() {
     });
 }
 
+function emulatorResetDeviceShamir() {
+    _send({
+        type: 'emulator-reset-device',
+        use_shamir: true,
+    });
+}
+
 function emulatorSetup() {
     const input = document.getElementById('seed-input');
     _send({

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,49 @@
+"""
+Pytest configuration file defining some useful functionality.
+"""
+
+import pytest
+import websockets
+
+from . import controller_test
+
+
+def pytest_addoption(parser):
+    """Adding CLI options."""
+    parser.addoption(
+        "--controller-already-runs",
+        action="store_true",
+        default=False,
+        help="Chosen when the controller is already running and we should not spawn it again.",
+    )
+
+
+def pytest_sessionstart(session):
+    """What should run before all the tests start."""
+    # When the controller is not running, spawning it
+    if session.config.getoption("controller_already_runs"):
+        print("\nController already runs, not touching it")
+    else:
+        print("\nStarting controller before tests")
+        controller_test.start_controller()
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """What should run after all the tests are finished."""
+    # When the controller was spawned by us, killing it
+    if session.config.getoption("controller_already_runs"):
+        print("\nController was already running, not touching it")
+    else:
+        print("\nKilling the controller after all tests")
+        controller_test.shutdown_controller()
+
+
+@pytest.fixture(scope="function")
+async def websocket():
+    """Injecting a websocket connection to test functions."""
+    # TODO: ws connection could be somehow cached, but I tried it through a
+    # global variable and it was not successful
+    async with websockets.connect(controller_test.URL) as ws:
+        # Catching the welcome message, so that it can be immediately used
+        await ws.recv()
+        yield ws

--- a/tests/controller_test.py
+++ b/tests/controller_test.py
@@ -1,0 +1,267 @@
+import asyncio
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+import websockets
+from psutil import Popen
+
+ROOT_DIR = Path(__file__).absolute().parent.parent.resolve()
+
+PORT = 9001
+HOST = "localhost"
+URL = f"ws://{HOST}:{PORT}"
+
+BRIDGE_TO_TEST = "2.0.31"
+EMU_TO_TEST_TT = "2-master"
+EMU_TO_TEST_T1 = "1-master"
+
+# So that the async tests are understood by pytest
+pytestmark = pytest.mark.asyncio
+
+# The "vectors" here should/must be executed in this exact order
+# We are spawning the bridge and emulator at the beginning to test `background-check`
+# and then all possible emulator commands that would not work without
+# running and setup emulator
+commands_success = [
+    {"type": "ping"},
+    {"type": "log", "text": "abc"},
+    {"type": "bridge-start", "version": BRIDGE_TO_TEST},
+    {"type": "emulator-start", "version": EMU_TO_TEST_TT, "wipe": True},
+    {"type": "background-check"},
+    {
+        "type": "emulator-setup",
+        "mnemonic": " ".join(["all"] * 12),
+        "pin": "1234",
+        "passphrase_protection": False,
+        "label": "My Trevor",
+    },
+    {"type": "emulator-apply-settings", "label": "label"},
+    {"type": "emulator-press-yes"},
+    {"type": "emulator-press-no"},
+    {"type": "emulator-input", "value": "all all all..."},
+    {"type": "emulator-click", "x": 123, "y": 121},
+    {"type": "emulator-allow-unsafe-paths"},
+    {"type": "select-num-of-words", "num": 12},
+    {"type": "emulator-swipe", "direction": "down"},
+    {"type": "emulator-wipe"},
+    {"type": "emulator-reset-device"},
+    {"type": "emulator-stop"},
+    {"type": "bridge-stop"},
+]
+
+# These could be run in any order, they are not dependent on each other
+commands_failure = [
+    {"type": "pong"},  # unexisting general command
+    {"type": "bridge-explode"},  # unexisting bridge command
+    {"type": "emulator-show-seed"},  # unexisting emulator command
+    {"type": "log", "string": "key should be text not string"},  # bad key
+    {
+        "type": "emulator-start",
+        "version": "2-notexisting",
+        "wipe": True,
+    },  # unexisting emulator
+    {
+        "type": "emulator-start",
+        "version": "1-notexisting",
+    },  # unexisting emulator
+    {
+        "type": "bridge-start",
+        "version": "2.0.unexisting",
+    },  # unexisting bridge
+    {"type": "emulator-press-yes"},  # no running emulator
+]
+
+
+def start_controller() -> None:
+    """Running the controller on the background.
+
+    Luckily, we do not have to care about killing the
+    thread/process/whatever-spawned-it, as the controller
+    can be killed from any client with `{"type": "exit"}` message
+    """
+    # WARNING: yes, it is ugly, but I tried some things with multithreading
+    # and multiprocessing and they either did not work or had some disadvantages
+    # The closest attempt `multiprocessing.Process(target=controller.start).start()`
+    # was spamming the console with controller logs, which we probably do not want
+
+    controller = Popen(
+        f"python {ROOT_DIR}/src/main.py",
+        shell=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.STDOUT,
+    )
+    print(f"Controller spawned: {controller}. CMD: {controller.cmdline()}")
+
+    time.sleep(2)
+
+    # Verifying if the controller is really running
+    if not controller.is_running():
+        raise RuntimeError(f"Controller {controller} is unable to run!")
+
+
+def shutdown_controller() -> None:
+    """Making sure the controller will stop."""
+
+    async def _shutdown_controller() -> None:
+        async with websockets.connect(URL) as websocket:  # type: ignore [attr-defined]
+            payload = {"type": "exit"}
+            await websocket.send(json.dumps(payload))
+
+    asyncio.get_event_loop().run_until_complete(_shutdown_controller())
+
+
+async def _test_start_stop(websocket, component: str, version: str) -> None:
+    """Making sure emulator/bridge can be successfully started and stopped."""
+    background_check_payload = {"type": "background-check"}
+    if component == "bridge":
+        status_key = "bridge_status"
+        start_payload = {"type": "bridge-start", "version": version}
+        stop_payload = {"type": "bridge-stop"}
+    elif component == "emulator":
+        status_key = "emulator_status"
+        start_payload = {"type": "emulator-start", "version": version}
+        stop_payload = {"type": "emulator-stop"}
+    else:
+        raise RuntimeError(f"Only emulator and bridge are supported, not {component}")
+
+    # Not running at the beginning
+    await websocket.send(json.dumps(background_check_payload))
+    response = json.loads(await websocket.recv())
+    print(response)
+    assert response["success"]
+    assert not response[status_key]["is_running"]
+
+    # Spawning it
+    await websocket.send(json.dumps(start_payload))
+    response = json.loads(await websocket.recv())
+    print(response)
+    assert response["success"]
+
+    # Is running after starting it
+    await websocket.send(json.dumps(background_check_payload))
+    response = json.loads(await websocket.recv())
+    print(response)
+    assert response["success"]
+    assert response[status_key]["is_running"]
+    assert response[status_key]["version"] == version
+
+    # Stopping it
+    await websocket.send(json.dumps(stop_payload))
+    response = json.loads(await websocket.recv())
+    print(response)
+    assert response["success"]
+
+    # Not running after stopping it
+    await websocket.send(json.dumps(background_check_payload))
+    response = json.loads(await websocket.recv())
+    print(response)
+    assert response["success"]
+    assert not response[status_key]["is_running"]
+
+
+async def _test(websocket, payload: dict, success: bool = True) -> None:
+    await websocket.send(json.dumps(payload))
+    response = json.loads(await websocket.recv())
+    print(response)
+    assert response["success"] == success
+
+
+async def test_bridge_start_stop(websocket) -> None:
+    await _test_start_stop(websocket, component="bridge", version=BRIDGE_TO_TEST)
+
+
+async def test_emulator_tt_start_stop(websocket) -> None:
+    await _test_start_stop(websocket, component="emulator", version=EMU_TO_TEST_TT)
+
+
+async def test_emulator_t1_start_stop(websocket) -> None:
+    await _test_start_stop(websocket, component="emulator", version=EMU_TO_TEST_T1)
+
+
+@pytest.mark.parametrize("payload", commands_success)
+async def test_successful(websocket, payload: dict) -> None:
+    await _test(websocket, payload, success=True)
+
+
+@pytest.mark.parametrize("payload", commands_failure)
+async def test_failure(websocket, payload: dict) -> None:
+    await _test(websocket, payload, success=False)
+
+
+@pytest.mark.skip("Emulator is frozen after device backup")
+async def test_read_and_confirm_mnemonic(websocket) -> None:
+    # Setting up emulator with a new seed
+    payload = {
+        "type": "emulator-start",
+        "id": 444,
+        "version": EMU_TO_TEST_TT,
+        "wipe": True,
+    }
+    await websocket.send(json.dumps(payload))
+    response = json.loads(await websocket.recv())
+    print("response", response)
+    assert response["success"]
+
+    payload = {"type": "emulator-reset-device", "id": 555}
+    await websocket.send(json.dumps(payload))
+    response = json.loads(await websocket.recv())
+    print(response)
+    assert response["success"]
+
+    # WARNING: this is not very nice, we should do it via trezorlib somehow
+    # We need to set trezor into backup mode without clicking anything else
+    # (the Debuglink would be actually clicking the OKs)
+    os.system("trezorctl device backup &")
+    time.sleep(1)
+
+    # Triggering the confirming walkthrough
+    payload = {"type": "emulator-read-and-confirm-mnemonic", "id": 666}
+    await websocket.send(json.dumps(payload))
+    response = json.loads(await websocket.recv())
+    print(response)
+    assert response["success"]
+    assert response["id"] == 666
+
+
+@pytest.mark.skip("Emulator is frozen after device backup")
+async def test_read_and_confirm_mnemonic_shamir(websocket) -> None:
+    # Setting up emulator with a new seed
+    payload = {
+        "type": "emulator-start",
+        "id": 444,
+        "version": EMU_TO_TEST_TT,
+        "wipe": True,
+    }
+    await websocket.send(json.dumps(payload))
+    response = json.loads(await websocket.recv())
+    print("response", response)
+    assert response["success"]
+
+    payload = {"type": "emulator-reset-device", "use_shamir": True, "id": 555}
+    await websocket.send(json.dumps(payload))
+    response = json.loads(await websocket.recv())
+    print(response)
+    assert response["success"]
+
+    # WARNING: this is not very nice, we should do it via trezorlib somehow
+    # We need to set trezor into backup mode without clicking anything else
+    # (the Debuglink would be actually clicking the OKs)
+    os.system("trezorctl device backup &")
+    time.sleep(1)
+
+    # Triggering the confirming walkthrough
+    payload = {
+        "type": "emulator-read-and-confirm-shamir-mnemonic",
+        "shares": 3,
+        "threshold": 2,
+        "id": 666,
+    }
+    await websocket.send(json.dumps(payload))
+    response = json.loads(await websocket.recv())
+    print(response)
+    assert response["success"]
+    assert response["id"] == 666


### PR DESCRIPTION
Connected with https://github.com/trezor/trezor-user-env/issues/90 and https://github.com/trezor/trezor-user-env/issues/122

So far just some basic tests of `controller`, trying to call most of its commands and checking if we receive a response with `success: True` (or `success: False` in case of purposely failing commands)

The `controller` currently has to run on the background (be started manually)

Next steps/ideas:
- automatically spawn the `controller` before the tests and kill it after them
- include `pytest`
- include it into `CI`
- some advanced functions are omitted now, as they are relying on specific emulator state - `"emulator-read-and-confirm-mnemonic"` and `emulator-read-and-confirm-shamir-mnemonic`
- could include the `regtest` - but that would require spinning up the `regtest` container