### PR TITLE
feat(ci): making the test image build manual

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -23,6 +23,7 @@ build and push image:
 build and push test image:
   stage: build
   <<: *build
+  when: manual
   except:
     - schedules
     - master


### PR DESCRIPTION
Connected with #128 - just a quick change of marking the test build manual.

As discussed with @tsusanka, it would be nice for the job to accept a parameter, but is not really necessary at the moment.

Making it manual makes sense on its own to save quite a lot of `CI` time and resources