### PR TITLE
chore(docker): pin to last working nix docker image

### DIFF
--- a/ci/prebuild.yml
+++ b/ci/prebuild.yml
@@ -1,4 +1,4 @@
-image: $CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX/nixos/nix:latest
+image: $CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX/nixos/nix:2.3.12
 
 code check prebuild:
   stage: prebuild

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM nixos/nix
+FROM nixos/nix:2.3.12
 
 # "fake" dbus address to prevent errors
 # https://github.com/SeleniumHQ/docker-selenium/issues/87


### PR DESCRIPTION
This fixes the issue with the latest docker image that was deployed by the nix community. It moves away from the alpine image and uses native nixos as a base. 