### PR TITLE
feat(emulator): emulator-get-screenshot command to return base64 encoded screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ emulator.img
 docker/version.txt
 logs/debugging.log
 logs/emulator_bridge.log
+logs/screens

--- a/docs/controller.md
+++ b/docs/controller.md
@@ -108,6 +108,10 @@
 - **emulator-reset-device**
   - **action**: reset the device
 
+- **emulator-get-screenshot**
+  - **action**: get current screen encoded as base64
+  - **response**: `{"response": str}`
+
 - **bridge-start**
   - **action**: start the specified version of bridge (only if it is not already running)
   - **arguments**:

--- a/src/controller.py
+++ b/src/controller.py
@@ -209,6 +209,9 @@ class ResponseGetter:
         elif self.command == "emulator-reset-device":
             emulator.reset_device()
             return {"response": "Device reset"}
+        elif self.command == "emulator-get-screenshot":
+            screen_base_64 = emulator.get_current_screen()
+            return {"response": screen_base_64}
         else:
             return {
                 "success": False,


### PR DESCRIPTION
Connected with https://github.com/trezor/trezor-user-env/issues/137

Allowing for clients to get the current screenshot of the device screen - encoded as a base64 string, so it can be transmitted through websocket in JSON format.

It is not the cleanest solution, as we need to save _all_ the screens, and when somebody requests current screenshot, we will return the latest one. That is because firmware currently does not have the functionality to save _just_ the current screen.