### PR TITLE
feat(emulator): adding save_screenshots argument to emulator-start

### DIFF
--- a/docs/controller.md
+++ b/docs/controller.md
@@ -27,15 +27,18 @@
   - **action**: start the specified version of emulator (and if one already runs, kills it)
   - **arguments**:
     - **version**: `str` (1.9.4, 2.4.0., etc.) - default is the latest TT
-    - **wipe**: `bool` whether to delete the emulator profile before starting it - default is False
-    - **output_to_logfile**: `bool` whether the debug output should go to a logfile - default is True - otherwise it goes to stdout
+    - **wipe**: `bool` (default=False) whether to delete the emulator profile before starting it
+    - **output_to_logfile**: `bool` (default=True) whether the debug output should go to a logfile - otherwise it goes to stdout
+    - **save_screenshots**: `bool` (default=False) whether to save screenshots to enable calling **emulator-get-screenshot**
 
 - **emulator-start-from-url**
   - **action**: downloads emulator from specified URL and runs it
   - **arguments**:
     - **url**: `str` from where to download the emulator
     - **model**: `str` which emulator it is - either "1" for T1 or "2" for T2
-    - **wipe**: `bool` whether to delete the emulator profile before starting it - default is False
+    - **wipe**: `bool` (default=False) whether to delete the emulator profile before starting it
+    - **output_to_logfile**: `bool` (default=True) whether the debug output should go to a logfile - otherwise it goes to stdout
+    - **save_screenshots**: `bool` (default=False) whether to save screenshots to enable calling **emulator-get-screenshot**
 
 - **emulator-stop**
   - **action**: stop the emulator
@@ -48,7 +51,7 @@
     - **pin**: `str`
     - **passphrase_protection**: `bool`
     - **label**: `str`
-    - **needs_backup**: `bool` - default is False
+    - **needs_backup**: `bool` (default=False)
 
 - **emulator-press-yes**
   - **action**: press yes button on the emulator
@@ -73,8 +76,8 @@
 - **emulator-read-and-confirm-shamir-mnemonic**
   - **action**: simulates the Shamir backup process for chosen amount of shares and threshold
   - **arguments**:
-    - **shares**: `int` (defaults to 1)
-    - **threshold**: `int` (defaults to 1)
+    - **shares**: `int` (default=1)
+    - **threshold**: `int` (default=1)
 
 - **emulator-allow-unsafe-paths**
   - **action**: allow unsafe path on emulator
@@ -116,7 +119,7 @@
   - **action**: start the specified version of bridge (only if it is not already running)
   - **arguments**:
     - **version**: `str` (2.0.27, 2.0.31, etc.) - defaults to the latest available one
-    - **output_to_logfile**: `bool` whether the debug output should go to a logfile - default is True - otherwise it goes to stdout
+    - **output_to_logfile**: `bool` (default=True) whether the debug output should go to a logfile, otherwise it goes to stdout
 
 - **bridge-stop**
   - **action**: stop the bridge

--- a/src/controller.py
+++ b/src/controller.py
@@ -129,7 +129,8 @@ class ResponseGetter:
             version = self.request_dict.get("version", binaries.FIRMWARES["TT"][0])
             wipe = self.request_dict.get("wipe", False)
             output_to_logfile = self.request_dict.get("output_to_logfile", True)
-            emulator.start(version, wipe, output_to_logfile)
+            save_screenshots = self.request_dict.get("save_screenshots", False)
+            emulator.start(version, wipe, output_to_logfile, save_screenshots)
             response_text = f"Emulator version {version} started"
             if wipe:
                 response_text += " and wiped to be empty"
@@ -139,7 +140,10 @@ class ResponseGetter:
             model = self.request_dict["model"]
             wipe = self.request_dict.get("wipe", False)
             output_to_logfile = self.request_dict.get("output_to_logfile", True)
-            emulator.start_from_url(url, model, wipe, output_to_logfile)
+            save_screenshots = self.request_dict.get("save_screenshots", False)
+            emulator.start_from_url(
+                url, model, wipe, output_to_logfile, save_screenshots
+            )
             response_text = f"Emulator downloaded from {url} and started"
             if wipe:
                 response_text += " and wiped to be empty"

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -61,7 +61,9 @@
             <input id="wipeDevice" type="checkbox">
             <label for="wipeDevice">Start with wiped/empty device</label>
             <input id="emulatorUseLogfile" type="checkbox">
-            <label for="emulatorUseLogfile">Logs into logfile</label><br>
+            <label for="emulatorUseLogfile">Logs into logfile</label>
+            <input id="emulatorSaveScreenshots" type="checkbox">
+            <label for="emulatorSaveScreenshots">Save screenshots</label><br>
         </div>
         <div>
             <input id="emu-url" type="text" placeholder="Full emulator URL, link to Gitlab job or just job ID - as specified in select. Do not forget to specify model (T1/T2)" style="width:50%;"/>
@@ -85,6 +87,7 @@
             <button onclick="emulatorPressYes();">Press yes</button>
             <button onclick="emulatorPressNo();">Press no</button>
             <button onclick="emulatorAllowUnsafe();">Allow unsafe (safety checks)</button>
+            <button onclick="emulatorGetScreenshot();">Get screenshot</button>
         </div>
         <div>
             <button onclick="readAndConfirmMnemonic();">Read and confirm mnemonic</button>

--- a/src/dashboard/index.js
+++ b/src/dashboard/index.js
@@ -140,11 +140,13 @@ function emulatorStart(select) {
     const version = document.getElementById(select).value;
     const wipe = document.getElementById("wipeDevice").checked;
     const output_to_logfile = document.getElementById("emulatorUseLogfile").checked;
+    const save_screenshots = document.getElementById("emulatorSaveScreenshots").checked;
     _send({
         type: 'emulator-start',
         version,
         wipe,
         output_to_logfile,
+        save_screenshots,
     });
 }
 
@@ -239,6 +241,12 @@ function emulatorAllowUnsafe() {
 function emulatorStop() {
     _send({
         type: 'emulator-stop',
+    });
+}
+
+function emulatorGetScreenshot() {
+    _send({
+        type: 'emulator-get-screenshot',
     });
 }
 

--- a/src/emulator.py
+++ b/src/emulator.py
@@ -103,7 +103,11 @@ def get_url_identifier(url: str) -> str:
 
 
 def start_from_url(
-    url: str, model: Literal["1", "2"], wipe: bool, output_to_logfile: bool = True
+    url: str,
+    model: Literal["1", "2"],
+    wipe: bool,
+    output_to_logfile: bool = True,
+    save_screenshots: bool = False,
 ) -> None:
     # Creating an identifier of emulator from this URL, so we have to
     # download it only once and can reuse it any time later
@@ -132,10 +136,15 @@ def start_from_url(
     else:
         log(f"Emulator from {url} already exists under {emu_path}")
 
-    return start(emu_name, wipe, output_to_logfile)
+    return start(emu_name, wipe, output_to_logfile, save_screenshots)
 
 
-def start(version: str, wipe: bool, output_to_logfile: bool = True) -> None:
+def start(
+    version: str,
+    wipe: bool,
+    output_to_logfile: bool = True,
+    save_screenshots: bool = False,
+) -> None:
     global version_running
     global EMULATOR
 
@@ -176,10 +185,10 @@ def start(version: str, wipe: bool, output_to_logfile: bool = True) -> None:
 
     version_running = version
 
-    # Saving the screenshots on any screen-change, so we can send the
+    # Optionally saving the screenshots on any screen-change, so we can send the
     # current screen on demand
     # Only applicable to TT, T1 is not capable of screenshotting
-    if version[0] == "2":
+    if save_screenshots and version[0] == "2":
         time.sleep(1)
         client = DebugLink(get_device().find_debug())
         client.open()
@@ -205,7 +214,9 @@ def get_current_screen() -> str:
     # so we take the latest file
     all_screenshots = list(SCREEN_DIR.glob("*.png"))
     if not all_screenshots:
-        raise RuntimeError("There are no screenshots")
+        raise RuntimeError(
+            "There are no screenshots. Did you start emulator with save_screenshots=True?"
+        )
     latest_screenshot = max(all_screenshots, key=lambda p: p.stat().st_ctime)
 
     with open(latest_screenshot, "rb") as f:


### PR DESCRIPTION
Improvement of https://github.com/trezor/trezor-user-env/pull/138

Creating optional argument to `emulator-start` (`save_screenshots`), defaulting to `False`, that should be switched to `True` when client want to use the new `emulator-get-screenshot` functionality.

Done like this because majority of clients will not use `emulator-get-screenshot`, and it would slow them down.