### PR TITLE
feat: pass strenght and backup_type to device.reset

### DIFF
--- a/src/controller.py
+++ b/src/controller.py
@@ -3,6 +3,7 @@ import json
 import traceback
 from copy import deepcopy
 
+from trezorlib import messages
 from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
 from websockets.server import serve
 
@@ -211,7 +212,10 @@ class ResponseGetter:
             emulator.apply_settings(**settings_fields)
             return {"response": f"Applied settings on emulator {settings_fields}"}
         elif self.command == "emulator-reset-device":
-            emulator.reset_device()
+            emulator.reset_device(
+                self.request_dict.get("backup_type", messages.BackupType.Bip39),
+                self.request_dict.get("strength"),
+            )
             return {"response": "Device reset"}
         elif self.command == "emulator-get-screenshot":
             screen_base_64 = emulator.get_current_screen()

--- a/src/emulator.py
+++ b/src/emulator.py
@@ -255,11 +255,17 @@ def wipe_device() -> None:
     client.close()
 
 
-def reset_device() -> None:
+def reset_device(backup_type: messages.BackupType, strength: int) -> None:
     client = TrezorClientDebugLink(get_device())
     client.open()
     time.sleep(SLEEP)
-    device.reset(client, skip_backup=True, pin_protection=False)
+    device.reset(
+        client,
+        skip_backup=True,
+        pin_protection=False,
+        backup_type=backup_type,
+        strength=strength,
+    )
     client.close()
 
 


### PR DESCRIPTION
Does it look correct? I had trouble running trezor-user-env locally. Kept getting 'emulator process died" but I gues it was not connected to these changes. So this is not tested yet. will try again tomorrow.