### PR TITLE
feat(emu, bridge): only show relevant binaries - ARM vs nonARM

### DIFF
--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -1,4 +1,5 @@
 <html>
+
 <head>
     <title>Trezor Device Controller client</title>
     <link rel="stylesheet" type="text/css" href="index.css" />
@@ -18,10 +19,8 @@
         <h3>Bridge</h3>
         <div>
             <i>Start Bridge with emulator support.</i><br>
-            <button onclick="bridgeStart('2.0.31')">Start 2.0.31</button>
-            <button onclick="bridgeStart('2.0.31-arm64')">Start 2.0.31-arm64</button>
-            <button onclick="bridgeStart('2.0.30-arm64')">Start 2.0.30-arm64</button>
-            <button onclick="bridgeStart('2.0.27')">Start 2.0.27</button>
+            <select id="bridge-select"></select>
+            <button onclick="bridgeStart('bridge-select')">Start</button>
             <button onclick="bridgeStop()">Stop</button>
             <input id="bridgeUseLogfile" type="checkbox">
             <label for="bridgeUseLogfile">Logs into logfile</label><br>
@@ -68,7 +67,9 @@
             <label for="emulatorSaveScreenshots">Save screenshots</label><br>
         </div>
         <div>
-            <input id="emu-url" type="text" placeholder="Full emulator URL, link to Gitlab job or just job ID - as specified in select. Do not forget to specify model (T1/T2)" style="width:50%;"/>
+            <input id="emu-url" type="text"
+                placeholder="Full emulator URL, link to Gitlab job or just job ID - as specified in select. Do not forget to specify model (T1/T2)"
+                style="width:50%;" />
             <select id="emu-url-format-select"></select>
             <select id="emu-url-model-select"></select>
             <button onclick="emulatorStartFromUrl();">Start from URL</button>
@@ -96,9 +97,9 @@
         </div>
         <div>
             <label for="shares-input">Shares</label>
-            <input id="shares-input" type="number" value="3" size="3" min="1" max="20"/>
+            <input id="shares-input" type="number" value="3" size="3" min="1" max="20" />
             <label for="threshold-input">Threshold</label>
-            <input id="threshold-input" type="number" value="2" size="3" min="1" max="20"/>
+            <input id="threshold-input" type="number" value="2" size="3" min="1" max="20" />
             <button onclick="readAndConfirmMnemonicShamir();">Read and confirm mnemonic Shamir</button>
         </div>
     </section>
@@ -121,4 +122,5 @@
 
     <script type="text/javascript" src="index.js"></script>
 </body>
+
 </html>

--- a/src/dashboard/index.js
+++ b/src/dashboard/index.js
@@ -48,6 +48,12 @@ const populateEmulatorSelect = (firmwares) => {
     firmwares['TT'].forEach(version => createOption(t2Select, version));
 };
 
+const populateBridgeSelect = (bridges) => {
+    const bridgeSelect = document.getElementById('bridge-select');
+    clearOptions(bridgeSelect);
+    bridges.forEach(bridge => createOption(bridgeSelect, bridge));
+};
+
 
 const handleMessage = (event) => {
     if (!event.data || typeof event.data !== 'string') {
@@ -79,6 +85,7 @@ const handleMessage = (event) => {
 
     if (dataObject.type === 'client') {
         populateEmulatorSelect(dataObject.firmwares);
+        populateBridgeSelect(dataObject.bridges);
     }
 };
 
@@ -250,7 +257,8 @@ function emulatorGetScreenshot() {
     });
 }
 
-function bridgeStart(version) {
+function bridgeStart(select) {
+    const version = document.getElementById(select).value;
     const output_to_logfile = document.getElementById("bridgeUseLogfile").checked;
     _send({
         type: 'bridge-start',


### PR DESCRIPTION
Connected with https://github.com/trezor/trezor-user-env/issues/147:
- making sure ARM machines will only show ARM emulators/bridges in `dashboard` and vice-versa