### PR TITLE
chore(controller): rename select-num-of-words cmd to emulator-select-num-of-words

### DIFF
--- a/docs/controller.md
+++ b/docs/controller.md
@@ -82,7 +82,7 @@
 - **emulator-allow-unsafe-paths**
   - **action**: allow unsafe path on emulator
 
-- **select-num-of-words**
+- **emulator-select-num-of-words**
   - **action**: set the number of seed words
   - **arguments**:
     - **num**: `int`

--- a/src/controller.py
+++ b/src/controller.py
@@ -93,9 +93,7 @@ class ResponseGetter:
             exit(1)
         elif self.command.startswith("bridge"):
             return self.run_bridge_command()
-        elif (
-            self.command.startswith("emulator") or self.command == "select-num-of-words"
-        ):
+        elif self.command.startswith("emulator"):
             return self.run_emulator_command()
         elif self.command.startswith("regtest"):
             return self.run_regtest_command()
@@ -191,7 +189,7 @@ class ResponseGetter:
         elif self.command == "emulator-allow-unsafe-paths":
             emulator.allow_unsafe()
             return {"response": "Allowed unsafe path"}
-        elif self.command == "select-num-of-words":
+        elif self.command == "emulator-select-num-of-words":
             num = self.request_dict["num"]
             emulator.select_num_of_words(num)
             return {"response": f"Selected {num} words"}

--- a/tests/controller_test.py
+++ b/tests/controller_test.py
@@ -45,7 +45,7 @@ commands_success = [
     {"type": "emulator-input", "value": "all all all..."},
     {"type": "emulator-click", "x": 123, "y": 121},
     {"type": "emulator-allow-unsafe-paths"},
-    {"type": "select-num-of-words", "num": 12},
+    {"type": "emulator-select-num-of-words", "num": 12},
     {"type": "emulator-swipe", "direction": "down"},
     {"type": "emulator-wipe"},
     {"type": "emulator-reset-device"},


### PR DESCRIPTION
Connected with https://github.com/trezor/trezor-user-env/issues/101:
- unifying `emulator-` prefixes for all emulator commands in controller

NOTE:
- it is a backwards-incompatible change, we agreed with @mroz22 that Suite tests will need to be changed after this