### PR TITLE
feat(controller): add `1-latest` and `2-latest` version arguments into `emulator-start`

### DIFF
--- a/docs/controller.md
+++ b/docs/controller.md
@@ -26,7 +26,8 @@
 - **emulator-start**
   - **action**: start the specified version of emulator (and if one already runs, kills it)
   - **arguments**:
-    - **version**: `str` (1.9.4, 2.4.0., etc.) - default is the latest TT
+    - **version**: `str` (1.9.4, 2.4.0., etc.) - default is the latest TT (`2-master`)
+      - `1-latest` and `2-latest` can be used to get the latest released version of that model
     - **wipe**: `bool` (default=False) whether to delete the emulator profile before starting it
     - **output_to_logfile**: `bool` (default=True) whether the debug output should go to a logfile - otherwise it goes to stdout
     - **save_screenshots**: `bool` (default=False) whether to save screenshots to enable calling **emulator-get-screenshot**

--- a/src/controller.py
+++ b/src/controller.py
@@ -124,8 +124,20 @@ class ResponseGetter:
             }
 
     def run_emulator_command(self) -> dict:
+        # The versions are sorted, the first one is the current master
+        # build and then the rest by version number.
+        # Not supplying any version will result in "2-master",
+        # "X-latest" will get the latest release of X.
         if self.command == "emulator-start":
-            version = self.request_dict.get("version", binaries.FIRMWARES["TT"][0])
+            if "version" in self.request_dict:
+                if self.request_dict["version"] == "1-latest":
+                    version = binaries.FIRMWARES["T1"][1]
+                elif self.request_dict["version"] == "2-latest":
+                    version = binaries.FIRMWARES["TT"][1]
+                else:
+                    version = self.request_dict["version"]
+            else:
+                version = binaries.FIRMWARES["TT"][0]
             wipe = self.request_dict.get("wipe", False)
             output_to_logfile = self.request_dict.get("output_to_logfile", True)
             save_screenshots = self.request_dict.get("save_screenshots", False)


### PR DESCRIPTION
Connected with https://github.com/trezor/trezor-user-env/issues/170
- adding `1-latest` and `2-latest` options as `version` argument into `emulator-start` websocket command

CC @mroz22 