### PR TITLE
feat(emu): add `emulator-get-debug-state` command

### DIFF
--- a/docs/controller.md
+++ b/docs/controller.md
@@ -114,10 +114,18 @@
   - **arguments**:
     - **use_shamir**: `bool` (optional) - whether to use Shamir backup (SLIP39) - default is False (BIP39 will be used)
 
-
 - **emulator-get-screenshot**
   - **action**: get current screen encoded as base64
   - **response**: `{"response": str}`
+
+- **emulator-get-debug-state**
+  - **action**: get current debug state, for example to check what is on the screen
+  - **response**: `{"response": dict}`
+  - **example responses**:
+    - T1: `{... "recovery_fake_word": "", "recovery_word_pos": 18, ...}`
+      - situation while doing T1 recovery - `recovery_word_pos` says that 18th word is currently requested
+    - TT: ` { ... "layout_lines": ["RecoveryHomescreen", "Select number of words", ""], ...}`
+      - `layout_lines` showing the current content of the screen
 
 - **bridge-start**
   - **action**: start the specified version of bridge (only if it is not already running)

--- a/src/controller.py
+++ b/src/controller.py
@@ -231,6 +231,9 @@ class ResponseGetter:
         elif self.command == "emulator-get-screenshot":
             screen_base_64 = emulator.get_current_screen()
             return {"response": screen_base_64}
+        elif self.command == "emulator-get-debug-state":
+            debug_state = emulator.get_debug_state()
+            return {"response": debug_state}
         else:
             return {
                 "success": False,

--- a/tests/controller_test.py
+++ b/tests/controller_test.py
@@ -49,6 +49,7 @@ commands_success = [
     {"type": "emulator-swipe", "direction": "down"},
     {"type": "emulator-wipe"},
     {"type": "emulator-reset-device"},
+    {"type": "emulator-get-debug-state"},
     {"type": "emulator-stop"},
     {"type": "bridge-stop"},
 ]


### PR DESCRIPTION
Connected with https://github.com/trezor/trezor-user-env/issues/169:
- allowing to get at least some basic information about what is on the emulator screen
- new `emulator-get-debug-state` websocket command, which will return an object with sometimes useful data

Use-case:
- during `T1` recovery, it contains for example `"recovery_fake_word": "dish"` when there is a fake word, or `"recovery_word_pos": 18` when Trezor asks for a real word
- for `TT`, the most useful is probably `"layout_lines": ["RecoveryHomescreen", "Select number of words", ""]`, which tells what is currently displayed on the screen

CC @ondracja @mroz22 - this most probably solves your issue, please try with a testing image (should be downloadable soon from `ghcr.io/trezor/trezor-user-env:173`)