### PR TITLE
fix: adding procps to nix-shell for checking emulator status by tenv

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -23,6 +23,8 @@ stdenv.mkDerivation {
     wget
     git
     unzip
+    curl
+    procps
   ];
   # NIX_PATH needed for autoPatchelfHook nix-shells in download.sh scripts
   NIX_PATH = "nixpkgs=${nixpkgsUrl}";


### PR DESCRIPTION
This fixes an issue with procps not present for checking emulator status in the new image.