### PR TITLE
Support model R emulators

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 src/binaries/firmware/repo/
 src/binaries/trezord-go/repo/
+docker/Dockerfile
+docker/compose.yml

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,8 +23,7 @@ RUN ls /
 RUN ls /trezor-user-env
 
 RUN nix-shell --run "./src/binaries/firmware/bin/download.sh"
-# patch emulator binaries for nix
-RUN nix-shell --run "autoPatchelf src/binaries/firmware/bin"
+RUN nix-shell --run "./patch_emulators.sh src/binaries/firmware/bin"
 RUN nix-shell --run "./src/binaries/trezord-go/bin/download.sh"
 
 RUN nix-shell --run "./docker/create_version_file.sh"

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -8,6 +8,7 @@ services:
       - DISPLAY=$DISPLAY
     volumes:
       - ./../logs/screens:/trezor-user-env/logs/screens
+      - ./../src/binaries/firmware/bin/user_downloaded:/trezor-user-env/src/binaries/firmware/bin/user_downloaded
 
   trezor-user-env-mac:
     container_name: trezor-user-env.mac
@@ -21,6 +22,7 @@ services:
       - DISPLAY=docker.for.mac.host.internal:0
     volumes:
       - ./../logs/screens:/trezor-user-env/logs/screens
+      - ./../src/binaries/firmware/bin/user_downloaded:/trezor-user-env/src/binaries/firmware/bin/user_downloaded
 
   trezor-user-env-regtest:
     container_name: trezor-user-env-regtest

--- a/patch_emulators.sh
+++ b/patch_emulators.sh
@@ -3,4 +3,8 @@
 FILE_DIR="$(dirname "${0}")"
 cd ${FILE_DIR}
 
-nix-shell --run "autoPatchelf src/binaries/firmware/bin"
+DIR_TO_PATCH="${1:-src/binaries/firmware/bin}"
+
+echo "Patching ${DIR_TO_PATCH}"
+
+nix-shell --run "autoPatchelf ${DIR_TO_PATCH}"

--- a/patch_emulators.sh
+++ b/patch_emulators.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+FILE_DIR="$(dirname "${0}")"
+cd ${FILE_DIR}
+
+nix-shell --run "autoPatchelf src/binaries/firmware/bin"

--- a/poetry.lock
+++ b/poetry.lock
@@ -353,6 +353,14 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "simple-rlp"
+version = "0.1.2"
+description = "RLP (Recursive Length Prefix) - Encode and decode data structures"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -386,25 +394,26 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "trezor"
-version = "0.13.0"
+version = "0.13.2"
 description = "Python library for communicating with Trezor Hardware Wallet"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-click = ">=7,<9"
-construct = ">=2.9"
+click = ">=7,<8.2"
+construct = ">=2.9,<2.10.55 || >2.10.55"
 ecdsa = ">=0.9"
 libusb1 = ">=1.6.4"
 mnemonic = ">=0.20"
 requests = ">=2.4.0"
+simple-rlp = {version = ">=0.1.2", markers = "python_version >= \"3.7\""}
 typing-extensions = ">=3.10"
 
 [package.extras]
-ethereum = ["rlp (>=1.1.0)", "web3 (>=4.8)"]
+ethereum = ["web3 (>=4.8)", "rlp (>=1.1.0)"]
 extra = ["pillow"]
-full = ["hidapi (>=0.7.99.post20)", "rlp (>=1.1.0)", "web3 (>=4.8)", "pyqt5", "pillow", "stellar-sdk (>=4.0.0,<6.0.0)"]
+full = ["hidapi (>=0.7.99.post20)", "web3 (>=4.8)", "pyqt5", "pillow", "stellar-sdk (>=4.0.0,<6.0.0)", "rlp (>=1.1.0)"]
 hidapi = ["hidapi (>=0.7.99.post20)"]
 qt-widgets = ["pyqt5"]
 stellar = ["stellar-sdk (>=4.0.0,<6.0.0)"]
@@ -441,7 +450,7 @@ python-versions = ">=3.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "0b5abb09040ef5e859a2f388abefc345c3e7c59503be76e52df9671635247d9e"
+content-hash = "5c0cf15f637ec22f29c0ad7e130a5044e62930ac9e1750311be6b725f3023795"
 
 [metadata.files]
 atomicwrites = [
@@ -677,6 +686,9 @@ requests = [
     {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
     {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
 ]
+simple-rlp = [
+    {file = "simple-rlp-0.1.2.tar.gz", hash = "sha256:5c4a9c58f1b742f7fa8af0fe4ea6ff9fb02294ae041912f771570dfaf339d2b9"},
+]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
@@ -693,8 +705,8 @@ tomli = [
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
 trezor = [
-    {file = "trezor-0.13.0-py3-none-any.whl", hash = "sha256:8c79aab2ea30440a4c6a1380c0373a848f11730bcde43b3de5280a927a8e82cc"},
-    {file = "trezor-0.13.0.tar.gz", hash = "sha256:4571aa09dbfe88b31eb2f16c7c359b4809621b75a04b7b5bc9dbffe17046c99a"},
+    {file = "trezor-0.13.2-py3-none-any.whl", hash = "sha256:32410690e756c0a37bf59eb087298366afa9cb8930cb450a766320e8d972d455"},
+    {file = "trezor-0.13.2.tar.gz", hash = "sha256:cdb696fd01dad6a0cb23b61ea3a4867bb51cecda5cb2a77366fb6a53bff58ac4"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.2.0-py3-none-any.whl", hash = "sha256:6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["SatoshiLabs <info@satoshilabs.com>"]
 [tool.poetry.dependencies]
 python = "^3.9"
 termcolor = "^1.1.0"
-trezor = "^0.13.0"
+trezor = "^0.13.2"
 websockets = "^10.1"
 psutil = "^5.8.0"
 Pillow = "^9.1.0"

--- a/src/binaries.py
+++ b/src/binaries.py
@@ -8,6 +8,8 @@ from termcolor import colored
 
 ROOT_DIR = Path(__file__).resolve().parent.parent
 FIRMWARE_BIN_DIR = ROOT_DIR / "src/binaries/firmware/bin"
+USER_DOWNLOADED_DIR = FIRMWARE_BIN_DIR / "user_downloaded"
+USER_DOWNLOADED_DIR.mkdir(exist_ok=True)
 
 Model = Literal["1", "2", "R"]
 FIRMWARES: Dict[Model, Dict[str, str]] = {
@@ -141,7 +143,7 @@ def explore_bridges() -> None:
         BRIDGES.append("2.0.19")
 
 
-def patch_emulators_for_nix() -> None:
+def patch_emulators_for_nix(dir_to_patch: str = "") -> None:
     """Make sure all the emulators can be run in Nix environment.
 
     When for some reason the script fails, it does not raise
@@ -149,4 +151,5 @@ def patch_emulators_for_nix() -> None:
     That is on purpose, because it might be run in a non-Nix
     environment.
     """
-    subprocess.run("./patch_emulators.sh", cwd=ROOT_DIR)
+    cmd = ["./patch_emulators.sh", dir_to_patch]
+    subprocess.run(cmd, cwd=ROOT_DIR)

--- a/src/binaries.py
+++ b/src/binaries.py
@@ -1,18 +1,21 @@
 import os
 import subprocess
+from collections import OrderedDict
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Literal, Tuple
 
 from termcolor import colored
 
 ROOT_DIR = Path(__file__).resolve().parent.parent
 FIRMWARE_BIN_DIR = ROOT_DIR / "src/binaries/firmware/bin"
 
-FIRMWARES: Dict[str, List[str]] = {
-    "T1": [],
-    "TT": [],
-    "TR": [],
+Model = Literal["1", "2", "R"]
+FIRMWARES: Dict[Model, Dict[str, str]] = {
+    "1": OrderedDict(),
+    "2": OrderedDict(),
+    "R": OrderedDict(),
 }
+
 BRIDGES: List[str] = []
 
 IS_ARM = os.uname().machine.startswith("aarch64")
@@ -21,6 +24,33 @@ ARM_IDENTIFIER = "-arm"
 IDENTIFIER_T1 = "trezor-emu-legacy-v"
 IDENTIFIER_TT = "trezor-emu-core-v"
 IDENTIFIER_TR = "trezor-emu-core-R-v"
+
+
+def register_new_firmware(model: Model, version: str, location: str) -> None:
+    FIRMWARES[model][version] = location
+
+
+def get_firmware_location(model: Model, version: str) -> str:
+    return FIRMWARES[model][version]
+
+
+def get_all_firmware_versions() -> dict[Model, list[str]]:
+    return {k: list(v.keys()) for k, v in FIRMWARES.items()}
+
+
+def get_latest_release_version(model: Model) -> str:
+    # Last index is the current master
+    return list(FIRMWARES[model].keys())[1]
+
+
+def get_master_version(model: Model) -> str:
+    return list(FIRMWARES[model].keys())[0]
+
+
+def check_model(model: str) -> None:
+    supported_models = FIRMWARES.keys()
+    if model not in supported_models:
+        raise RuntimeError(f"Unknown model {model} - supported are {supported_models}")
 
 
 def _print_in_verbose(text: str, args: Any) -> None:
@@ -38,7 +68,7 @@ def explore_firmwares(args: Any) -> None:
 
     # Analyzing all potential emulator files and gathering their versions
     #   (version is located at the end, after emulator identifier)
-    for fw_file in FIRMWARE_BIN_DIR.glob("*"):
+    for fw_file in FIRMWARE_BIN_DIR.rglob("*"):
         fw = fw_file.name
 
         # Send only suitable emulators for ARM/non-ARM
@@ -50,24 +80,34 @@ def explore_firmwares(args: Any) -> None:
             continue
 
         if IDENTIFIER_TR in fw:
+            model: Model = "R"
             version = fw.split(IDENTIFIER_TR)[-1]
-            FIRMWARES["TR"].append(version)
         elif IDENTIFIER_TT in fw:
+            model = "2"
             version = fw.split(IDENTIFIER_TT)[-1]
-            FIRMWARES["TT"].append(version)
         elif IDENTIFIER_T1 in fw:
+            model = "1"
             version = fw.split(IDENTIFIER_T1)[-1]
-            FIRMWARES["T1"].append(version)
         else:
             _print_in_verbose(f"  skipping {colored(fw, 'yellow')}", args)
             continue
+
+        # Registering the found firmware and saving its absolute location
+        register_new_firmware(model, version, fw_file.absolute().as_posix())
 
         _print_in_verbose(
             f"  found {colored(fw, 'yellow')} => {colored(version, 'magenta')}", args
         )
 
-    for model in FIRMWARES.values():
-        model.sort(key=sort_firmwares, reverse=True)
+    # Sorting the model versions according to their numerical value
+    for model_name, model_info in FIRMWARES.items():
+        FIRMWARES[model_name] = OrderedDict(
+            sorted(
+                model_info.items(),
+                key=lambda item: sort_firmwares(item[0]),
+                reverse=True,
+            )
+        )
 
 
 def sort_firmwares(version: str) -> Tuple[int, ...]:

--- a/src/binaries.py
+++ b/src/binaries.py
@@ -5,15 +5,25 @@ from typing import Any, Dict, List, Tuple
 
 from termcolor import colored
 
-ROOT_DIR = Path(__file__).parent.parent.resolve()
+ROOT_DIR = Path(__file__).resolve().parent.parent
 FIRMWARES: Dict[str, List[str]] = {
     "T1": [],
     "TT": [],
+    "TR": [],
 }
 BRIDGES: List[str] = []
 
 IS_ARM = os.uname().machine.startswith("aarch64")
 ARM_IDENTIFIER = "-arm"
+
+IDENTIFIER_T1 = "trezor-emu-legacy-v"
+IDENTIFIER_TT = "trezor-emu-core-v"
+IDENTIFIER_TR = "trezor-emu-core-R-v"
+
+
+def _print_in_verbose(text: str, args: Any) -> None:
+    if args.verbosity > 0:
+        print(text)
 
 
 def explore(args: Any) -> None:
@@ -23,35 +33,35 @@ def explore(args: Any) -> None:
 
 def explore_firmwares(args: Any) -> None:
     firmware_binary_files = str(ROOT_DIR / "src/binaries/firmware/bin/*")
-    if args.verbosity > 0:
-        print(f"Scanning {colored(firmware_binary_files, 'yellow')}")
+    _print_in_verbose(f"Scanning {colored(firmware_binary_files, 'yellow')}", args)
 
     # Analyzing all potential emulator files and gathering their versions
-    #   (version is located at the end, after emulator identifier and '-v')
-    identifier_TT = "trezor-emu-core"
-    identifier_T1 = "trezor-emu-legacy"
+    #   (version is located at the end, after emulator identifier)
     for fw in glob.glob(firmware_binary_files):
         # Send only suitable emulators for ARM/non-ARM
         if IS_ARM and not fw.endswith(ARM_IDENTIFIER):
-            print(f"On ARM, ignoring x86 emulator - {fw}")
+            _print_in_verbose(f"On ARM, ignoring x86 emulator - {fw}", args)
             continue
         elif not IS_ARM and fw.endswith(ARM_IDENTIFIER):
-            print(f"On x86, ignoring ARM emulator - {fw}")
+            _print_in_verbose(f"On x86, ignoring ARM emulator - {fw}", args)
             continue
 
-        if identifier_TT in fw:
-            version = fw.split(identifier_TT + "-v")[-1]
+        if IDENTIFIER_TR in fw:
+            version = fw.split(IDENTIFIER_TR)[-1]
+            FIRMWARES["TR"].append(version)
+        elif IDENTIFIER_TT in fw:
+            version = fw.split(IDENTIFIER_TT)[-1]
             FIRMWARES["TT"].append(version)
-        elif identifier_T1 in fw:
-            version = fw.split(identifier_T1 + "-v")[-1]
+        elif IDENTIFIER_T1 in fw:
+            version = fw.split(IDENTIFIER_T1)[-1]
             FIRMWARES["T1"].append(version)
         else:
-            if args.verbosity > 0:
-                print(f"  skipping {colored(fw, 'yellow')}")
+            _print_in_verbose(f"  skipping {colored(fw, 'yellow')}", args)
             continue
 
-        if args.verbosity > 0:
-            print(f"  found {colored(fw, 'yellow')} => {colored(version, 'magenta')}")
+        _print_in_verbose(
+            f"  found {colored(fw, 'yellow')} => {colored(version, 'magenta')}", args
+        )
 
     for model in FIRMWARES.values():
         model.sort(key=sort_firmwares, reverse=True)
@@ -59,14 +69,21 @@ def explore_firmwares(args: Any) -> None:
 
 def sort_firmwares(version: str) -> Tuple[int, ...]:
     # Having master and url versions as the first one in the list
-    if "master" in version or "url" in version:
+    if "master" in version:
         return 99, 99, 99
+    elif "url" in version:
+        return 88, 88, 88
 
     # Removing the possible ARM-related suffix just for sorting, wont rename the file
     if version.endswith(ARM_IDENTIFIER):
         version = version[: -len(ARM_IDENTIFIER)]
 
-    return tuple(int(n) for n in version.split("."))
+    # When the version is not \d+.\d+.\d+, make it be just below master and URL versions,
+    # so that it is well visible in the dashboard (is a custom user version)
+    try:
+        return tuple(int(n) for n in version.split("."))
+    except ValueError:
+        return 77, 77, 77
 
 
 def explore_bridges() -> None:

--- a/src/binaries/firmware/bin/download.sh
+++ b/src/binaries/firmware/bin/download.sh
@@ -6,12 +6,20 @@ SYSTEM_ARCH=$(uname -m)
 if [[ $SYSTEM_ARCH == x86_64* ]]; then
     SITE="https://data.trezor.io/dev/firmware/releases/emulators/"
     CORE_LATEST_BUILD="https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/artifacts/master/download?job=core%20unix%20frozen%20debug%20build"
+    # WARNING: just temporary
+    # It should get the build from master branch, but it does not
+    # have all the needed functionality. Using custom branch for now.
+    R_LATEST_BUILD="https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/2498092190/artifacts/raw/core/build/unix/trezor-emu-core"
     LEGACY_LATEST_BUILD="https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/artifacts/master/download?job=legacy%20emu%20regular%20debug%20build"
     CUT_DIRS=4
 
 elif [[ $SYSTEM_ARCH == aarch64* ]]; then
     SITE="https://data.trezor.io/dev/firmware/releases/emulators/arm/"
     CORE_LATEST_BUILD="https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/artifacts/master/download?job=core%20unix%20frozen%20debug%20build%20arm"
+    # WARNING: just temporary
+    # It should get the build from master branch, but it does not
+    # have all the needed functionality. Using custom branch for now.
+    R_LATEST_BUILD="https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/2510249260/artifacts/raw/core/build/unix/trezor-emu-core-arm"
     LEGACY_LATEST_BUILD="https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/artifacts/master/download?job=legacy%20emu%20regular%20debug%20build%20arm"
     CUT_DIRS=5
 
@@ -51,6 +59,9 @@ if [[ $SYSTEM_ARCH == x86_64* ]]; then
     unzip -q trezor-emu-legacy-master.zip
     mv legacy/firmware/trezor.elf ../trezor-emu-legacy-v1-master
 
+    wget --no-config -O trezor_r_master_emu "$R_LATEST_BUILD"
+    mv trezor_r_master_emu ../trezor-emu-core-R-v2-master
+
 elif [[ $SYSTEM_ARCH == aarch64* ]]; then
     wget --no-config -O trezor-emu-core-arm-master.zip "$CORE_LATEST_BUILD"
     unzip -q trezor-emu-core-arm-master.zip -d arm/
@@ -59,6 +70,9 @@ elif [[ $SYSTEM_ARCH == aarch64* ]]; then
     wget --no-config -O trezor-emu-legacy-arm-master.zip "$LEGACY_LATEST_BUILD"
     unzip -q trezor-emu-legacy-arm-master.zip -d arm/
     mv arm/legacy/firmware/trezor-arm.elf ../trezor-emu-legacy-v1-master-arm
+
+    wget --no-config -O trezor_r_master_emu_arm "$R_LATEST_BUILD"
+    mv trezor_r_master_emu_arm ../trezor-emu-core-R-v2-master-arm
 fi
 
 cd "$BIN_DIR"

--- a/src/controller.py
+++ b/src/controller.py
@@ -130,14 +130,14 @@ class ResponseGetter:
         # "X-latest" will get the latest release of X.
         if self.command == "emulator-start":
             if "version" in self.request_dict:
-                if self.request_dict["version"] == "1-latest":
-                    version = binaries.FIRMWARES["T1"][1]
-                elif self.request_dict["version"] == "2-latest":
-                    version = binaries.FIRMWARES["TT"][1]
+                requested_version = self.request_dict["version"]
+                if requested_version.endswith("-latest"):
+                    model = requested_version[0]
+                    version = binaries.get_latest_release_version(model)
                 else:
-                    version = self.request_dict["version"]
+                    version = requested_version
             else:
-                version = binaries.FIRMWARES["TT"][0]
+                version = binaries.get_master_version("2")
             # Model is not compulsory for backwards compatibility purposes
             # Is needed now, because TR and TT are sharing the same versions
             # (default to the first character in version, which works fine for
@@ -307,7 +307,7 @@ async def welcome(websocket) -> None:
     intro = {
         "type": "client",
         "id": "TODO",
-        "firmwares": binaries.FIRMWARES,
+        "firmwares": binaries.get_all_firmware_versions(),
         "bridges": binaries.BRIDGES,
     }
     await websocket.send(json.dumps(intro))

--- a/src/controller.py
+++ b/src/controller.py
@@ -138,11 +138,22 @@ class ResponseGetter:
                     version = self.request_dict["version"]
             else:
                 version = binaries.FIRMWARES["TT"][0]
+            # Model is not compulsory for backwards compatibility purposes
+            # Is needed now, because TR and TT are sharing the same versions
+            # (default to the first character in version, which works fine for
+            # "legacy" T1 and TT setup - `2.5.0`, `2-master`, `1.10.1`, etc.)
+            model = self.request_dict.get("model", version[0])
             wipe = self.request_dict.get("wipe", False)
             output_to_logfile = self.request_dict.get("output_to_logfile", True)
             save_screenshots = self.request_dict.get("save_screenshots", False)
-            emulator.start(version, wipe, output_to_logfile, save_screenshots)
-            response_text = f"Emulator version {version} started"
+            emulator.start(
+                version=version,
+                model=model,
+                wipe=wipe,
+                output_to_logfile=output_to_logfile,
+                save_screenshots=save_screenshots,
+            )
+            response_text = f"Emulator version {version} ({model}) started"
             if wipe:
                 response_text += " and wiped to be empty"
             return {"response": response_text}
@@ -153,7 +164,11 @@ class ResponseGetter:
             output_to_logfile = self.request_dict.get("output_to_logfile", True)
             save_screenshots = self.request_dict.get("save_screenshots", False)
             emulator.start_from_url(
-                url, model, wipe, output_to_logfile, save_screenshots
+                url=url,
+                model=model,
+                wipe=wipe,
+                output_to_logfile=output_to_logfile,
+                save_screenshots=save_screenshots,
             )
             response_text = f"Emulator downloaded from {url} and started"
             if wipe:

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -33,6 +33,15 @@ class Dashboard(SimpleHTTPRequestHandler):
             % (self.address_string(), self.log_date_time_string(), format % args)
         )
 
+    def end_headers(self):
+        self.send_my_headers()
+        SimpleHTTPRequestHandler.end_headers(self)
+
+    def send_my_headers(self):
+        self.send_header("Cache-Control", "no-cache, no-store, must-revalidate")
+        self.send_header("Pragma", "no-cache")
+        self.send_header("Expires", "0")
+
 
 class ThreadingServer(ThreadingMixIn, HTTPServer):
     pass

--- a/src/dashboard/index.css
+++ b/src/dashboard/index.css
@@ -3,13 +3,16 @@
     padding: 0;
 }
 
-html, body {
+html,
+body {
     width: 100%;
     height: 100%;
     background: #f4f4f4;
 }
 
-button, select, input[type=submit] {
+button,
+select,
+input[type=submit] {
     padding: 2px;
     cursor: pointer;
     min-width: 170px;
@@ -68,4 +71,10 @@ section {
 
 .underlined {
     text-decoration: underline #000 dotted;
+}
+
+.user-info {
+    font-weight: bold;
+    color: red;
+    font-size: 32px;
 }

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -60,6 +60,11 @@
             <button onclick="emulatorStart('t2-select');">Start</button>
         </div>
         <div>
+            <h4>Trezor R</h4>
+            <select id="tr-select"></select>
+            <button onclick="emulatorStart('tr-select');">Start</button>
+        </div>
+        <div>
             <input id="wipeDevice" type="checkbox">
             <label class="underlined" title="Device will be started without seed or any other settings."
                 for="wipeDevice">Start with wiped/empty device</label>
@@ -70,17 +75,16 @@
             <br>
             <input id="emulatorSaveScreenshots" type="checkbox">
             <label class="underlined" title="
-No red square in top right corner.
+No square in top right corner.
 Screenshots are saved under `logs/screens`.
 NOTE:
-- currently works only for TT
-- the first screen does contain the red square, no way to change it." for="emulatorSaveScreenshots">Screenshot
+- the first screen does contain the square, no way to change it." for="emulatorSaveScreenshots">Screenshot
                 mode</label>
             <br>
         </div>
         <div>
             <input id="emu-url" type="text"
-                placeholder="Full emulator URL, link to Gitlab job or just job ID - as specified in select. Do not forget to specify model (T1/T2)"
+                placeholder="Full emulator URL, link to Gitlab job or just job ID - as specified in select. Do not forget to specify model (T1/T2/TR)"
                 style="width:50%;" />
             <select id="emu-url-format-select"></select>
             <select id="emu-url-model-select"></select>

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -92,6 +92,10 @@ NOTE:
             <button onclick="emulatorStartFromUrl();">Start from URL</button>
         </div>
 
+        <div id="emu_url_info" class="user-info">
+            <!-- Filled when downloading from URL, which takes long time -->
+        </div>
+
         <hr>
 
         <h3>Emulator commands</h3>

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -78,6 +78,7 @@
 No square in top right corner.
 Screenshots are saved under `logs/screens`.
 NOTE:
+- does not work for T1
 - the first screen does contain the square, no way to change it." for="emulatorSaveScreenshots">Screenshot
                 mode</label>
             <br>

--- a/src/dashboard/index.js
+++ b/src/dashboard/index.js
@@ -90,6 +90,12 @@ const handleMessage = (event) => {
         populateEmulatorSelect(dataObject.firmwares);
         populateBridgeSelect(dataObject.bridges);
     }
+
+    // When emulator got successfully downloaded, remove its message
+    if ('response' in dataObject && dataObject.response.includes("Emulator downloaded")) {
+        document.getElementById("emu_url_info").innerHTML = "";
+        document.getElementById("emu_url_info").style.visibility = 'hidden';
+    }
 };
 
 function init() {
@@ -211,7 +217,8 @@ function emulatorStartFromUrl() {
         save_screenshots,
     });
 
-    alert('Emulator started downloading, it may take a while...');
+    document.getElementById("emu_url_info").innerHTML = "Emulator started downloading, it may take a while...";
+    document.getElementById("emu_url_info").style.visibility = 'visible';
 }
 
 function emulatorWipe() {

--- a/src/dashboard/index.js
+++ b/src/dashboard/index.js
@@ -46,9 +46,9 @@ const populateEmulatorSelect = (firmwares) => {
     clearOptions(t1Select);
     clearOptions(t2Select);
     clearOptions(trSelect);
-    firmwares['T1'].forEach(version => createOption(t1Select, version));
-    firmwares['TT'].forEach(version => createOption(t2Select, version));
-    firmwares['TR'].forEach(version => createOption(trSelect, version));
+    firmwares['1'].forEach(version => createOption(t1Select, version));
+    firmwares['2'].forEach(version => createOption(t2Select, version));
+    firmwares['R'].forEach(version => createOption(trSelect, version));
 };
 
 const populateBridgeSelect = (bridges) => {
@@ -210,6 +210,8 @@ function emulatorStartFromUrl() {
         output_to_logfile,
         save_screenshots,
     });
+
+    alert('Emulator started downloading, it may take a while...');
 }
 
 function emulatorWipe() {

--- a/src/dashboard/index.js
+++ b/src/dashboard/index.js
@@ -174,6 +174,7 @@ function emulatorStartFromUrl() {
     const urlFormat = document.getElementById("emu-url-format-select").value;
     const wipe = document.getElementById("wipeDevice").checked;
     const output_to_logfile = document.getElementById("emulatorUseLogfile").checked;
+    const save_screenshots = document.getElementById("emulatorSaveScreenshots").checked;
 
     const gitlabJobPrefix = "https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs"
     const T1PathSuffix = "artifacts/raw/legacy/firmware/trezor.elf"
@@ -207,6 +208,7 @@ function emulatorStartFromUrl() {
         model,
         wipe,
         output_to_logfile,
+        save_screenshots,
     });
 }
 

--- a/src/dashboard/index.js
+++ b/src/dashboard/index.js
@@ -42,10 +42,13 @@ const clearOptions = (select) => {
 const populateEmulatorSelect = (firmwares) => {
     const t1Select = document.getElementById('t1-select');
     const t2Select = document.getElementById('t2-select');
+    const trSelect = document.getElementById('tr-select');
     clearOptions(t1Select);
     clearOptions(t2Select);
+    clearOptions(trSelect);
     firmwares['T1'].forEach(version => createOption(t1Select, version));
     firmwares['TT'].forEach(version => createOption(t2Select, version));
+    firmwares['TR'].forEach(version => createOption(trSelect, version));
 };
 
 const populateBridgeSelect = (bridges) => {
@@ -145,12 +148,14 @@ function onCloseClick() {
 
 function emulatorStart(select) {
     const version = document.getElementById(select).value;
+    const model = select.substring(1, 2).toUpperCase();  // t1-select, t2-select, tr-select
     const wipe = document.getElementById("wipeDevice").checked;
     const output_to_logfile = document.getElementById("emulatorUseLogfile").checked;
     const save_screenshots = document.getElementById("emulatorSaveScreenshots").checked;
     _send({
         type: 'emulator-start',
         version,
+        model,
         wipe,
         output_to_logfile,
         save_screenshots,
@@ -164,7 +169,7 @@ function emulatorStartFromUrl() {
         return
     }
 
-    // Taking the last character - "1" or "2" from the model
+    // Taking the last character - "1", "2" or "R" from the model
     const model = document.getElementById("emu-url-model-select").value.substr(-1);
     const urlFormat = document.getElementById("emu-url-format-select").value;
     const wipe = document.getElementById("wipeDevice").checked;
@@ -172,6 +177,7 @@ function emulatorStartFromUrl() {
 
     const gitlabJobPrefix = "https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs"
     const T1PathSuffix = "artifacts/raw/legacy/firmware/trezor.elf"
+    // TR shares things with T2 here
     const T2PathSuffix = "artifacts/raw/core/build/unix/trezor-emu-core"
 
     // URL might need some processing in case it is not complete
@@ -357,9 +363,10 @@ window.onload = function () {
     watchBackgroundStatus();
     document.getElementById('raw-input').value = templateJSON;
 
-    const t1orT2Select = document.getElementById('emu-url-model-select');
-    createOption(t1orT2Select, "T2")
-    createOption(t1orT2Select, "T1")
+    const urlModelSelect = document.getElementById('emu-url-model-select');
+    createOption(urlModelSelect, "T2")
+    createOption(urlModelSelect, "T1")
+    createOption(urlModelSelect, "TR")
 
     const urlFormatSelect = document.getElementById('emu-url-format-select');
     createOption(urlFormatSelect, "Gitlab job link")

--- a/src/emulator.py
+++ b/src/emulator.py
@@ -203,7 +203,12 @@ def start(
     if wipe and EMULATOR.storage.exists():
         EMULATOR.storage.unlink()
 
-    EMULATOR.start()
+    try:
+        EMULATOR.start()
+    except Exception:
+        # When emulators fails to start, setting it to empty state not to cause issues later
+        EMULATOR = None
+        raise
 
     log(f"Emulator spawned. PID: {EMULATOR.process.pid}. CMD: {EMULATOR.process.args}")
 

--- a/src/emulator.py
+++ b/src/emulator.py
@@ -223,8 +223,7 @@ def start(
     # Optionally saving the screenshots on any screen-change, so we can send the
     # current screen on demand
     # Creating a new directory for each emulator session, so the screens are not being overwritten
-    # Only applicable to TT, T1 does not yet have screenshot support in current trezorlib
-    if save_screenshots and version[0] == "2":
+    if save_screenshots:
         time.sleep(1)
         client = DebugLink(get_device().find_debug())
         client.open()

--- a/src/emulator.py
+++ b/src/emulator.py
@@ -14,7 +14,7 @@ from urllib.error import HTTPError
 from psutil import Popen
 from trezorlib import debuglink, device, messages
 from trezorlib._internal.emulator import CoreEmulator, LegacyEmulator
-from trezorlib.debuglink import DebugLink, TrezorClientDebugLink
+from trezorlib.debuglink import TrezorClientDebugLink
 from trezorlib.exceptions import TrezorFailure
 from trezorlib.transport import Transport
 from trezorlib.transport.bridge import BridgeTransport
@@ -225,13 +225,16 @@ def start(
     # Optionally saving the screenshots on any screen-change, so we can send the
     # current screen on demand
     # Creating a new directory for each emulator session, so the screens are not being overwritten
-    if save_screenshots:
-        time.sleep(1)
-        client = DebugLink(get_device().find_debug())
-        client.open()
-        dir_to_save = get_new_screenshot_dir()
-        log(f"Saving screenshots to {dir_to_save}")
-        client.start_recording(str(dir_to_save))
+    # NOT supported for T1, as it needs Debuglink for screenshot creation, and therefore
+    # it would not save screenshots for example from Suite and other interaction.
+    if save_screenshots and model != "1":
+        time.sleep(SLEEP)
+        with connect_to_trezor() as client:
+            # Need to set model info (both TT and TR are under same category)
+            client.debug.model = "T"
+            dir_to_save = get_new_screenshot_dir()
+            log(f"Saving screenshots to {dir_to_save}")
+            client.debug.start_recording(str(dir_to_save))
 
 
 def get_new_screenshot_dir() -> Path:

--- a/src/emulator.py
+++ b/src/emulator.py
@@ -29,7 +29,6 @@ version_running = None
 EMULATOR = None
 
 ROOT_DIR = Path(__file__).resolve().parent.parent
-FIRMWARE_BIN_DIR = ROOT_DIR / "src/binaries/firmware/bin"
 
 SCREEN_DIR = ROOT_DIR / "logs/screens"
 SCREEN_DIR.mkdir(exist_ok=True)
@@ -119,11 +118,11 @@ def start_from_url(
     # Deciding the location to save depending on being T1/TT/TR
     # (to be compatible with already existing emulators)
     if model == "1":
-        emu_path = FIRMWARE_BIN_DIR / f"{binaries.IDENTIFIER_T1}{emu_name}"
+        emu_path = binaries.USER_DOWNLOADED_DIR / f"{binaries.IDENTIFIER_T1}{emu_name}"
     elif model == "2":
-        emu_path = FIRMWARE_BIN_DIR / f"{binaries.IDENTIFIER_TT}{emu_name}"
+        emu_path = binaries.USER_DOWNLOADED_DIR / f"{binaries.IDENTIFIER_TT}{emu_name}"
     elif model == "R":
-        emu_path = FIRMWARE_BIN_DIR / f"{binaries.IDENTIFIER_TR}{emu_name}"
+        emu_path = binaries.USER_DOWNLOADED_DIR / f"{binaries.IDENTIFIER_TR}{emu_name}"
 
     # Downloading only if it does not yet exist
     if not emu_path.is_file():
@@ -139,7 +138,7 @@ def start_from_url(
         # (patching fail will not cause any python error,
         # so there will be no problems even for machines without Nix)
         emu_path.chmod(emu_path.stat().st_mode | stat.S_IEXEC)
-        binaries.patch_emulators_for_nix()
+        binaries.patch_emulators_for_nix(str(binaries.USER_DOWNLOADED_DIR))
         # Registering the new emulator so we know its locations
         binaries.register_new_firmware(model, emu_name, str(emu_path))
     else:
@@ -193,14 +192,14 @@ def start(
     if model in ("2", "R"):
         EMULATOR = CoreEmulator(
             emu_location,
-            profile_dir=FIRMWARE_BIN_DIR,
+            profile_dir=binaries.FIRMWARE_BIN_DIR,
             logfile=logfile,
         )
     elif model == "1":
         os.environ["TREZOR_OLED_SCALE"] = str(TREZOR_ONE_OLED_SCALE)
         EMULATOR = LegacyEmulator(
             emu_location,
-            profile_dir=str(FIRMWARE_BIN_DIR),
+            profile_dir=str(binaries.FIRMWARE_BIN_DIR),
             logfile=logfile,
         )
 

--- a/src/emulator.py
+++ b/src/emulator.py
@@ -134,8 +134,12 @@ def start_from_url(
             err = f"HTTP error when downloading emulator from {url}, err: {e}"
             log(err, "red")
             raise RuntimeError(err)
-        # We need to run chmod +x on the newly downloaded file
+        # Running chmod +x on the newly downloaded emulator and
+        # patching it so it can run in Nix
+        # (patching fail will not cause any python error,
+        # so there will be no problems even for machines without Nix)
         emu_path.chmod(emu_path.stat().st_mode | stat.S_IEXEC)
+        binaries.patch_emulators_for_nix()
     else:
         log(f"Emulator from {url} already exists under {emu_path}")
 

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from termcolor import colored
 
-ROOT_DIR = Path(__file__).parent.parent.resolve()
+ROOT_DIR = Path(__file__).resolve().parent.parent
 LOG_DIR = ROOT_DIR / "logs"
 
 # Creating log dir here, so it does not need to be included in repository


### PR DESCRIPTION
Connected with https://github.com/trezor/trezor-user-env/issues/176:
- supporting model R in `tenv`

Is a little hacky, for couple of reasons/limitations:
- we need the latest `trezorlib` for `model R` support, but it is unreleased
  - I am unable to install it from our github repo through `poetry install` ([known issue](https://github.com/python-poetry/poetry/issues/755)), so I am doing it manually through `pip` in `Dockerfile` as a last step
- we need functional `model R` emulator(s), but they are not yet released
  - in current `master` we do have it running, just with a very limited capabilities
  - therefore, I am hardcoding download of from the "most featured branch" currently ([grdddj/trezor_r_passphrase_input](https://github.com/trezor/trezor-firmware/tree/grdddj/trezor_r_passphrase_input)), which has prototypes of PIN entry, seed backup, seed recovery and passphrase entry

It is however easily possible for anybody to download any branch through the `Start from URL` feature - just giving it URL to some Gitlab job of `core unix frozen R debug build` (for example https://gitlab.com/satoshilabs/trezor/trezor-firmware/-/jobs/2498092302) and choosing `TR`.

What is currently missing is support for `ARM` - sorry guys @vdovhanych @sime @tsusanka - but it could be possible to add some `model R ARM build` info `firmware CI` :) 