### PR TITLE
fix(emu): set emulator to empty state when it fails to start

### DIFF
--- a/src/emulator.py
+++ b/src/emulator.py
@@ -189,7 +189,12 @@ def start(
     if wipe and EMULATOR.storage.exists():
         EMULATOR.storage.unlink()
 
-    EMULATOR.start()
+    try:
+        EMULATOR.start()
+    except Exception:
+        # When emulators fails to start, setting it to empty state not to cause issues
+        EMULATOR = None
+        raise
 
     log(f"Emulator spawned. PID: {EMULATOR.process.pid}. CMD: {EMULATOR.process.args}")
 


### PR DESCRIPTION
Loosely connected with https://github.com/trezor/trezor-user-env/issues/179:
- currently, when somebody uses `Start from URL` from `Docker`, it will fail to start the emulator, but also blocks any other (even valid) emulator to be started
  - (because when trying to stop the "nonrunning" emulator, it will cause an exception)
- solving it by setting `EMULATOR = None` in case it does not start, so we know it is not running (and will not try to stop it) 