### PR TITLE
Support for physical Trezor

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -6,6 +6,10 @@ services:
     network_mode: "host"
     environment:
       - DISPLAY=$DISPLAY
+      # NOTE: it is possible to combine docker container and hardware device,
+      # but only for Linux, and only if the Trezor bridge is running locally.
+      # Second option of running with HW device is running the whole `tenv` locally.
+      - PHYSICAL_TREZOR=$PHYSICAL_TREZOR
     volumes:
       - ./../logs/screens:/trezor-user-env/logs/screens
       - ./../src/binaries/firmware/bin/user_downloaded:/trezor-user-env/src/binaries/firmware/bin/user_downloaded

--- a/run.sh
+++ b/run.sh
@@ -11,6 +11,7 @@ XHOST_ADDRESS=""
 SERVICE_NAME=""
 OPEN=""
 PULL=1
+PHYSICAL_TREZOR=0
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 function usage() {
@@ -20,6 +21,7 @@ function usage() {
   echo "Usage: $0 [-r --no-regtest] [-p --no-pull]"
   echo "  -r, --no-regtest      Run tenv only, no regtest"
   echo "  -p, --no-pull         Do not pull changes, neither git nor docker. Automatically set to True when not on 'master'"
+  echo "  -t, --trezor          Support for physical Trezor instead of an emulator. WARNING: only forks for Linux, not MacOS."
   echo ""
 }
 
@@ -27,6 +29,7 @@ function usage() {
 while [[ "$#" > 0 ]]; do case $1 in
   -r|--no-regtest) TENV_REGTEST=""; shift;;
   -p|--no-pull) PULL=0; shift;;
+  -t|--trezor) PHYSICAL_TREZOR=1; shift;;
   -h|--help) usage; exit 0; shift;;
   *) usage "${RED}Unknown parameter passed: $1${CLEAR}\n"; exit 1; shift;;
 esac; done
@@ -70,6 +73,12 @@ fi
 
 # open localhost:9002 in web browser after the controller is launched
 (while ! $(curl $DASHBOARD_URL -s -o /dev/null); do sleep 1; done; $OPEN $DASHBOARD_URL)&
+
+if [[ $PHYSICAL_TREZOR -eq 1 ]]; then
+    echo "Will support physical Trezor instead of emulator."
+    # this env variable is being passed to the docker environment
+    export PHYSICAL_TREZOR=1
+fi
 
 # launch trezor-user-env
 docker-compose -f ./docker/compose.yml up --force-recreate $SERVICE_NAME $TENV_REGTEST

--- a/src/bridge.py
+++ b/src/bridge.py
@@ -28,7 +28,13 @@ def is_running() -> bool:
 
 
 def get_status() -> dict:
-    return {"is_running": is_running(), "version": version_running}
+    if helpers.physical_trezor():
+        return {
+            "is_running": is_running(),
+            "version": f"{version_running} - PHYSICAL_TREZOR",
+        }
+    else:
+        return {"is_running": is_running(), "version": version_running}
 
 
 def is_port_in_use(port: int) -> bool:
@@ -73,7 +79,13 @@ def start(version: str, proxy: bool = False, output_to_logfile: bool = True) -> 
             f"Bridge does not exist for version {version} under {bridge_location}"
         )
 
-    command = f"{bridge_location} -ed 21324:21325 -u=false"
+    # In case user wants to use a physical device, not adding any arguments
+    # to the bridge. These arguments make the bridge optimized for emulators.
+    command = (
+        bridge_location
+        if helpers.physical_trezor()
+        else f"{bridge_location} -ed 21324:21325 -u=false"
+    )
 
     # Conditionally redirecting the output to a logfile instead of terminal/stdout
     if output_to_logfile:

--- a/src/emulator.py
+++ b/src/emulator.py
@@ -95,7 +95,10 @@ def is_running() -> bool:
 
 
 def get_status() -> dict[str, Any]:
-    return {"is_running": is_running(), "version": version_running}
+    if helpers.physical_trezor():
+        return {"is_running": True, "version": "PHYSICAL_TREZOR"}
+    else:
+        return {"is_running": is_running(), "version": version_running}
 
 
 def get_url_identifier(url: str) -> str:

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -7,6 +7,9 @@ from termcolor import colored
 ROOT_DIR = Path(__file__).resolve().parent.parent
 LOG_DIR = ROOT_DIR / "logs"
 
+PHYSICAL_TREZOR_ENV = "PHYSICAL_TREZOR"
+TRUE_VAL = "1"
+
 # Creating log dir here, so it does not need to be included in repository
 if not os.path.exists(LOG_DIR):
     os.mkdir(LOG_DIR)
@@ -25,3 +28,8 @@ logging.basicConfig(
 def log(text: str, color: str = "blue") -> None:
     logging.info(text)
     print(colored(text, color))
+
+
+def physical_trezor() -> bool:
+    """Whether we should support physical Trezor."""
+    return os.environ.get(PHYSICAL_TREZOR_ENV, "") == TRUE_VAL

--- a/src/main.py
+++ b/src/main.py
@@ -56,4 +56,12 @@ if __name__ == "__main__":
         log("Will create bridge proxy when spawning a bridge.")
         controller.BRIDGE_PROXY = True
 
+    if helpers.physical_trezor():
+        log("Will support physical Trezor.")
+    else:
+        log(
+            f"Will support emulator. Set {helpers.PHYSICAL_TREZOR_ENV}={helpers.TRUE_VAL} "
+            "env var to enable physical Trezor support."
+        )
+
     controller.start()


### PR DESCRIPTION
Making `tenv` compatible with a physical `Trezor`, so it can be used for some automated tasks/tests in debug mode.

The biggest difference is in the spawning of `bridge` - by default for emulators, it is run with `-u=false`, which disables listening on `USB`. For a physical device, we do not add any arguments to the `bridge`.

To avoid confusion for users, dashboard shows that `tenv` is expected to work with a physical device - in both the `bridge` and `emulator` sections:
(it does not actually check if the physical Trezor is connected, but we could add it)

![image](https://user-images.githubusercontent.com/42543243/182890299-ca3d2815-807e-438d-b1da-200a11aab5bf.png)


Support for physical `Trezor` is enabled by `$PHYSICAL_TREZOR` env variable.

`run.sh` script has a new `-t` flag, that will set it inside the container.