### PR TITLE
fix: test regtest controller over host.docker.internal

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -24,6 +24,7 @@ services:
       - "127.0.0.1:21325:21326" # macos needs proxy to override the "origin" of the trezord request
     environment:
       - DISPLAY=docker.for.mac.host.internal:0
+      - REGTEST_RPC_URL="http://host.docker.internal:18021"
     volumes:
       - ./../logs/screens:/trezor-user-env/logs/screens
       - ./../src/binaries/firmware/bin/user_downloaded:/trezor-user-env/src/binaries/firmware/bin/user_downloaded

--- a/src/controller.py
+++ b/src/controller.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import os
 import traceback
 from copy import deepcopy
 
@@ -18,7 +19,7 @@ PORT = 9001
 LOG_COLOR = "blue"
 BRIDGE_PROXY = False  # is being set in main.py (when not disabled, will be True)
 REGTEST_RPC = BTCJsonRPC(
-    url="http://0.0.0.0:18021",
+    url=os.getenv("REGTEST_RPC_URL") or "http://0.0.0.0:18021",
     user="rpc",
     passwd="rpc",
 )


### PR DESCRIPTION
the use case for this: 
when a mac user wants to run cypress tests native this allows the cypress test to send commands to regtest container from a different container (tenv in this case) 

test (localhost) -> tenv (container) -> tenv to regtest on locahost (container 2) typically, this doesn't work, but when we use `http://host.docker.internal`, it should work.