### PR TITLE
feat(dashboard): add regtest section to interact with backend

### DIFF
--- a/src/controller.py
+++ b/src/controller.py
@@ -24,6 +24,15 @@ REGTEST_RPC = BTCJsonRPC(
 )
 
 
+def is_regtest_active() -> bool:
+    """Finds out whether the regtest backend is running."""
+    try:
+        REGTEST_RPC.getblockchaininfo()
+        return True
+    except Exception:
+        return False
+
+
 def log(text: str, color: str = LOG_COLOR) -> None:
     helpers.log(f"CONTROLLER: {text}", color)
 
@@ -80,10 +89,12 @@ class ResponseGetter:
         elif self.command == "background-check":
             bridge_status = bridge.get_status()
             emulator_status = emulator.get_status()
+            regtest_status = is_regtest_active()
             return {
                 "response": "Background check done",
                 "bridge_status": bridge_status,
                 "emulator_status": emulator_status,
+                "regtest_status": regtest_status,
                 "background_check": True,
             }
         elif self.command == "exit":
@@ -258,7 +269,7 @@ class ResponseGetter:
     def run_regtest_command(self) -> dict:
         if self.command == "regtest-mine-blocks":
             block_amount = self.request_dict["block_amount"]
-            address = self.request_dict.get("address", REGTEST_RPC.getnewaddress())
+            address = self.request_dict.get("address") or REGTEST_RPC.getnewaddress()
             REGTEST_RPC.generatetoaddress(block_amount, address)
             return {"response": f"Mined {block_amount} blocks by address {address}"}
         elif self.command == "regtest-send-to-address":

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -126,6 +126,32 @@ NOTE:
     </section>
 
     <section>
+        <h3>Regtest</h3>
+
+        <div id="regtest-status-line">
+            <b>Status: <span id="regtest-status">unknown</span></b>
+        </div>
+
+        <label for="regtest-mine-blocks">Blocks</label>
+        <input id="regtest-mine-blocks" type="number" value="1" size="5" min="1" max="10000" />
+        <br />
+        <label for="regtest-mine-address">Optional address of a miner</label>
+        <input id="regtest-mine-address" size="62" />
+        <br />
+        <button onclick="regtestMine();">Mine regtest block(s)</button>
+
+        <hr />
+
+        <label for="regtest-send-amount">BTC amount</label>
+        <input id="regtest-send-amount" type="number" value="10" size="10" step="any"/>
+        <br />
+        <label for="regtest-send-address">Regtest address</label>
+        <input id="regtest-send-address" size="62" />
+        <br />
+        <button onclick="regtestSend();">Send regtest BTC to address</button>
+    </section>
+
+    <section>
         <h3>Server</h3>
         <textarea id="raw-input" rows="3"></textarea>
         <br />

--- a/src/dashboard/index.js
+++ b/src/dashboard/index.js
@@ -319,12 +319,35 @@ function readAndConfirmMnemonicShamir() {
     });
 }
 
+function regtestMine() {
+    const block_amount = parseInt(document.getElementById("regtest-mine-blocks").value);
+    const address = document.getElementById("regtest-mine-address").value;
+    _send({
+        type: 'regtest-mine-blocks',
+        block_amount,
+        address,
+    });
+}
+
+function regtestSend() {
+    const btc_amount = parseFloat(document.getElementById("regtest-send-amount").value);
+    const address = document.getElementById("regtest-send-address").value;
+    _send({
+        type: 'regtest-send-to-address',
+        btc_amount,
+        address,
+    });
+}
+
 function reflectBackgroundSituationInGUI(dataObject) {
     if ('bridge_status' in dataObject) {
         reflectBridgeSituation(dataObject.bridge_status);
     }
     if ('emulator_status' in dataObject) {
         reflectEmulatorSituation(dataObject.emulator_status);
+    }
+    if ('regtest_status' in dataObject) {
+        reflectRegtestSituation(dataObject.regtest_status);
     }
 }
 
@@ -349,6 +372,14 @@ function reflectEmulatorSituation(status) {
     }
 }
 
+function reflectRegtestSituation(is_running) {
+    if (is_running) {
+        writeRegtestStatus(`Running`, 'green');
+    } else {
+        writeRegtestStatus('Stopped', 'red');
+    }
+}
+
 function getBackgroundStatus() {
     _sendOnBackground({
         type: 'background-check',
@@ -363,6 +394,11 @@ function writeBridgeStatus(status, color = 'black') {
 function writeEmulatorStatus(status, color = 'black') {
     document.getElementById('emu-status').innerHTML = status;
     document.getElementById('emu-status-line').style["color"] = color;
+}
+
+function writeRegtestStatus(status, color = 'black') {
+    document.getElementById('regtest-status').innerHTML = status;
+    document.getElementById('regtest-status-line').style["color"] = color;
 }
 
 function watchBackgroundStatus() {


### PR DESCRIPTION
Connected with https://github.com/trezor/trezor-user-env/issues/106:
- creating a section in dashboard dedicated to `regtest` and allowing to interact with it

Allows for mining any number of blocks and for sending `rBTC` into a specified address.

![image](https://user-images.githubusercontent.com/42543243/198303211-a716074b-3317-4f85-9d8a-2b9930f022bd.png)
