### PR TITLE
Feat: emulator lock and pin sequence

### DIFF
--- a/src/controller.py
+++ b/src/controller.py
@@ -201,6 +201,9 @@ class ResponseGetter:
             y = self.request_dict["y"]
             emulator.click(x=x, y=y)
             return {"response": f"Clicked in emulator: x: {x}, y: {y}"}
+        elif self.command == "emulator-lock":
+            emulator.lock()
+            return {"response": f"Device locked"}
         elif self.command == "emulator-read-and-confirm-mnemonic":
             emulator.read_and_confirm_mnemonic()
             return {"response": "Read and confirm mnemonic"}

--- a/src/controller.py
+++ b/src/controller.py
@@ -201,6 +201,10 @@ class ResponseGetter:
             y = self.request_dict["y"]
             emulator.click(x=x, y=y)
             return {"response": f"Clicked in emulator: x: {x}, y: {y}"}
+        elif self.command == "emulator-use_pin_sequence":
+            sequence = self.request_dict["sequence"]
+            emulator.use_pin_sequence(sequence)
+            return {"response": f"Seq: {sequence}"}
         elif self.command == "emulator-lock":
             emulator.lock()
             return {"response": f"Device locked"}

--- a/src/emulator.py
+++ b/src/emulator.py
@@ -377,7 +377,6 @@ def press_no() -> None:
 
 
 # enter recovery word or pin
-# enter pin not possible for T2, it is locked, for T1 it is possible
 # change pin possible, use input(word=pin-string)
 def input(value: str) -> None:
     with connect_to_debuglink() as debug:
@@ -399,6 +398,11 @@ def swipe(direction: str) -> None:
             debug.swipe_down()
         elif direction == "left":
             debug.swipe_left()
+
+def use_pin_sequence(sequence) -> None:
+    with connect_to_client() as client:
+        client.use_pin_sequence(sequence)
+        time.sleep(SLEEP)
 
 def lock() -> None:
     with connect_to_client() as client:

--- a/src/emulator.py
+++ b/src/emulator.py
@@ -400,6 +400,10 @@ def swipe(direction: str) -> None:
         elif direction == "left":
             debug.swipe_left()
 
+def lock() -> None:
+    with connect_to_client() as client:
+        client.lock()
+        time.sleep(SLEEP)
 
 def read_and_confirm_mnemonic() -> None:
     with connect_to_debuglink() as debug:


### PR DESCRIPTION
leaving for @mroz22 to pick it up some day :)

- immediately lock device instead of waiting for auto lock usefull for connect authorizeCoinjoin tests
- (not finished) use pin_sequence like [trezor-firmware](https://github.com/trezor/trezor-firmware/blob/master/tests/device_tests/test_msg_changepin_t2.py#L51-L67)  tests useful for e2e suite test change pin