### PR TITLE
docs: add info about need for non-root docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Supported platforms are Linux and macOS (both Intel and Silicon).
 
 ### Prerequisites
 
-- Docker
+- Docker (on Linux, you need to be able to run it as non-root user, follow [those steps](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user))
 - xhost on Linux
 - [XQuartz](https://www.xquartz.org/) on macOS. Configure > Preferences > Security > Allow connections from network clients
 - Reboot (sign out/sign in might work)


### PR DESCRIPTION
- `./run.sh` will fail if docker is allowed in root mode only