### PR TITLE
Fix/download emulators

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,10 +2,16 @@ src/binaries/firmware/repo/
 src/binaries/trezord-go/repo/
 docker/Dockerfile
 docker/compose.yml
+tests
+docs
 .git
+.github
 .dockerignore
 .gitignore
 .vscode
+.editorconfig
 **/__pycache__
 **/.mypy_cache
 **/.pytest_cache
+Makefile
+README.md

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__
 src/binaries/firmware/bin/*
 !src/binaries/firmware/bin/download.sh
 !src/binaries/firmware/bin/download_latest_gh.py
+!src/binaries/firmware/bin/patch_emulators.sh
 !src/binaries/firmware/bin/arm
 !src/binaries/trezord-go/bin/download.sh
 emulator.img

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,7 +59,6 @@ WORKDIR ./trezor-user-env
 
 RUN nix-shell --run "poetry install --without dev --no-root && rm -rf $POETRY_CACHE_DIR" \
   && nix-shell --run "./src/binaries/firmware/bin/download.sh" \
-  && nix-shell --run "./patch_emulators.sh src/binaries/firmware/bin" \
   && nix-shell --run "./src/binaries/trezord-go/bin/download.sh"
 
 CMD nix-shell --run "./run-nix.sh"

--- a/src/binaries.py
+++ b/src/binaries.py
@@ -157,5 +157,5 @@ def patch_emulators_for_nix(dir_to_patch: str = "") -> None:
     That is on purpose, because it might be run in a non-Nix
     environment.
     """
-    cmd = ["./patch_emulators.sh", dir_to_patch]
+    cmd = ["./src/binaries/firmware/bin/patch_emulators.sh", dir_to_patch]
     subprocess.run(cmd, cwd=ROOT_DIR)

--- a/src/binaries/firmware/bin/download.sh
+++ b/src/binaries/firmware/bin/download.sh
@@ -3,8 +3,10 @@ set -e -o pipefail
 
 SYSTEM_ARCH=$(uname -m)
 
-cd "$(dirname "${BASH_SOURCE[0]}")"
-BIN_DIR=$(pwd)
+ROOT_DIR=$(pwd)
+BIN_DIR=$(dirname $(realpath -s $0))
+
+cd "$BIN_DIR"
 
 # WARNING: this will download the emulators from the latest SUCCESSFULLY run pipeline from trezor-firmware.
 # If the pipeline fails, it will download from the previous successful run.
@@ -96,3 +98,7 @@ strip trezor-emu-*
 
 # no need for Mac builds
 rm -rf macos
+
+cd "$ROOT_DIR"
+
+sh "$BIN_DIR"/patch_emulators.sh

--- a/src/binaries/firmware/bin/download.sh
+++ b/src/binaries/firmware/bin/download.sh
@@ -29,7 +29,7 @@ else
    exit 1
 fi
 
-if ! wget --no-config -e robots=off --no-verbose --no-clobber --no-parent --cut-dirs=$CUT_DIRS --no-host-directories --recursive --reject "index.html*" "$SITE"; then
+if ! wget --no-config -e robots=off --no-verbose --no-clobber --no-parent --cut-dirs=$CUT_DIRS --no-host-directories --reject "index.html*" "$SITE"; then
     echo "Unable to fetch released emulators from $SITE"
     echo "You will have only available latest builds from CI"
     echo

--- a/src/binaries/firmware/bin/patch_emulators.sh
+++ b/src/binaries/firmware/bin/patch_emulators.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
+set -e -o pipefail
 
 FILE_DIR="$(dirname "${0}")"
-cd ${FILE_DIR}
 
-DIR_TO_PATCH="${1:-src/binaries/firmware/bin}"
+DIR_TO_PATCH="${1:-$FILE_DIR}"
 
 echo "Patching ${DIR_TO_PATCH}"
 


### PR DESCRIPTION
1. fix firmware download script, currently it downloads arm emulators in `x86_64` arch because of `--recursive` option (it reads from both emulators/index.html and emulators/arm/index.html)

screenshot from current `ghcr.io/trezor/trezor-user-env`

![Screenshot from 2024-06-07 17-26-06](https://github.com/trezor/trezor-user-env/assets/3435913/51242320-1a52-493d-9d68-a7a165b82b79)



2. move `patch_emulator.sh` script to firmware directory and call it from the `download.sh` script. i always forget to do that (on nixos) and it's not mentioned by the docs

3. remove some unnecessary files from the docker image (perhaps there is even more?)