### PR TITLE
Enable mempoolfullrbf=1 for Regtest

### DIFF
--- a/docker/bitcoin-regtest/entrypoint.sh
+++ b/docker/bitcoin-regtest/entrypoint.sh
@@ -5,7 +5,7 @@ set -e
 cd /opt/coins/nodes/bitcoin_regtest
 
 echo "Starting bitcoin regtest backend service"
-bin/bitcoind -blockfilterindex -datadir=/opt/coins/data/bitcoin_regtest/backend -conf=/opt/coins/nodes/bitcoin_regtest/bitcoin_regtest.conf &
+bin/bitcoind -blockfilterindex -mempoolfullrbf=1 -datadir=/opt/coins/data/bitcoin_regtest/backend -conf=/opt/coins/nodes/bitcoin_regtest/bitcoin_regtest.conf &
 
 sleep 5
 


### PR DESCRIPTION
With implementation of https://github.com/trezor/trezor-suite/issues/13160 and https://github.com/trezor/trezor-suite/issues/13159 it would be useful to make this config consistent with it.