### PR TITLE
chore: change docker-compose commands to docker compose

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -59,7 +59,7 @@ if [[ $PULL -eq 1 ]]; then
     fi
 
     echo -e "Downloading latest images"
-    docker-compose -f ./docker/compose.yml pull $SERVICE_NAME $TENV_REGTEST
+    docker compose -f ./docker/compose.yml pull $SERVICE_NAME $TENV_REGTEST
 fi
 
 echo -e "Setup xhost for video device output"
@@ -83,4 +83,4 @@ else
 fi
 
 # launch trezor-user-env
-docker-compose -f ./docker/compose.yml up --force-recreate $SERVICE_NAME $TENV_REGTEST
+docker compose -f ./docker/compose.yml up --force-recreate $SERVICE_NAME $TENV_REGTEST


### PR DESCRIPTION
With the newest Docker Desktop release, I am getting `docker-compose: command not found` when running `./run.sh`.

See https://docs.docker.com/desktop/release-notes/#known-issues.

I tested the change to `docker compose` on a computer with lower version of Docker (v26) and it worked so hopefully this won't break anything.