### PR TITLE
fix: bridge proxy kill children as well

### DIFF
--- a/src/bridge_proxy.py
+++ b/src/bridge_proxy.py
@@ -34,9 +34,9 @@ def start() -> None:
 
     file_path = os.path.join(os.path.dirname(__file__), "bridge_proxy_server.py")
 
-    command = f"python {file_path}"
+    command_list = ["python", file_path]
 
-    BRIDGE_PROXY = Popen(command, shell=True)
+    BRIDGE_PROXY = Popen(command_list)
     log(f"Bridge proxy spawned: {BRIDGE_PROXY}. CMD: {BRIDGE_PROXY.cmdline()}")
 
     # Verifying if the proxy is really running
@@ -54,4 +54,9 @@ def stop() -> None:
     else:
         BRIDGE_PROXY.kill()
         log(f"Bridge proxy killed: {BRIDGE_PROXY}")
+        # Ensuring all child processes are cleaned up
+        for child in BRIDGE_PROXY.children(recursive=True):
+            log(f"Killing child process {child.pid}")
+            child.kill()
+            child.wait()
         BRIDGE_PROXY = None


### PR DESCRIPTION
I think the bridge proxy has an issue with left over processes, so they should be killed the same way as in bridge.

It's not a critical issue, but gets rid of some errors such as this:
<img width="812" alt="Screenshot 2024-09-06 at 09 56 52" src="https://github.com/user-attachments/assets/6ed6ff64-7945-4256-9279-0d62237c2dc1">
