### PR TITLE
Read and confirm mnemonic - T2T1 and T3T1

### DIFF
--- a/docs/controller.md
+++ b/docs/controller.md
@@ -128,6 +128,12 @@
     - TT: ` { ... "layout_lines": ["RecoveryHomescreen", "Select number of words", ""], ...}`
       - `layout_lines` showing the current content of the screen
 
+- **emulator-get-screen-content**
+  - **action**: get current screen content
+  - **response**: `{"response": {"title": str, "body": str}}`
+  - **example response**:
+    - `{'title': 'Create wallet backup', 'body': 'Your wallet backup contains 12 words in a specific order.'}`
+
 - **bridge-start**
   - **action**: start the specified version of bridge (only if it is not already running)
   - **arguments**:

--- a/src/controller.py
+++ b/src/controller.py
@@ -300,6 +300,9 @@ class ResponseGetter:
         elif self.command == "emulator-get-debug-state":
             debug_state = emulator.get_debug_state()
             return {"response": debug_state}
+        elif self.command == "emulator-get-screen-content":
+            content = emulator.get_screen_content()
+            return {"response": content}  # type: ignore
         else:
             return {
                 "success": False,

--- a/src/emulator.py
+++ b/src/emulator.py
@@ -651,8 +651,11 @@ def get_debug_state() -> Dict[str, Any]:
             # Not interested in private attributes and non-JSON fields (bytes)
             if key.startswith("__") or key[0].isupper():
                 continue
-            if val is not None and not isinstance(val, (list, str, bool, int)):
-                continue
+            if isinstance(val, bytes):
+                try:
+                    val = val.decode("utf-8")
+                except UnicodeDecodeError:
+                    val = val.hex()
 
             debug_state_dict[key] = val
 

--- a/src/emulator.py
+++ b/src/emulator.py
@@ -10,7 +10,7 @@ from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 from subprocess import PIPE
-from typing import Any, Dict, Generator, Optional
+from typing import Any, Dict, Generator, Optional, TypedDict
 from urllib.error import HTTPError
 
 from psutil import Popen
@@ -683,7 +683,7 @@ def get_debug_state() -> Dict[str, Any]:
     # We need to connect on UDP not to interrupt any bridge sessions
     with connect_to_debuglink(needs_udp=True) as debug:
         debug_state = debug.state()
-        debug_state_dict = {}
+        debug_state_dict: Dict[str, Any] = {}
         for key in dir(debug_state):
             val = getattr(debug_state, key)
             # Not interested in private attributes and non-JSON fields (bytes)
@@ -698,6 +698,19 @@ def get_debug_state() -> Dict[str, Any]:
             debug_state_dict[key] = val
 
         return debug_state_dict
+
+
+class ScreenContent(TypedDict):
+    title: str
+    body: str
+
+
+def get_screen_content() -> ScreenContent:
+    with connect_to_debuglink(needs_udp=True) as debug:
+        layout = debug.read_layout()
+        title = layout.title()
+        body = layout.text_content()
+        return {"title": title, "body": body}
 
 
 # For testing/debugging purposes

--- a/src/emulator.py
+++ b/src/emulator.py
@@ -421,6 +421,8 @@ def swipe(direction: str) -> None:
             debug.swipe_down()
         elif direction == "left":
             debug.swipe_left()
+        else:
+            raise ValueError(f"Unknown direction: {direction}")
 
 
 def assert_text_on_screen(debug: DebugLink, text: str) -> None:


### PR DESCRIPTION
Fixed/added `read_and_confirm_mnemonic` for `T2T1` (12 words + Shamir) and `T3T1` (12, 20, 24 words one share)

Also added a new API method - `emulator-get-screen-content` ... getting a current screen title and text