### PR TITLE
fix: make all the commands work even with the new node bridge - use UDP

### DIFF
--- a/src/emulator.py
+++ b/src/emulator.py
@@ -306,7 +306,7 @@ def get_current_screen() -> str:
 
 @contextmanager
 def connect_to_client(
-    needs_udp: bool = False,
+    needs_udp: bool = True,
 ) -> Generator[TrezorClientDebugLink, None, None]:
     """Connect to the emulator and yield a client instance.
     Disconnect after the action is done.
@@ -328,7 +328,7 @@ def connect_to_client(
 
 @contextmanager
 def connect_to_debuglink(
-    needs_udp: bool = False,
+    needs_udp: bool = True,
 ) -> Generator[DebugLink, None, None]:
     """Connect to the emulator and yield a debuglink instance.
     Disconnect after the action is done.
@@ -514,7 +514,7 @@ def read_and_confirm_mnemonic_t2t1() -> None:
 
 
 def read_and_confirm_mnemonic_t3t1() -> None:
-    with connect_to_debuglink(needs_udp=True) as debug:
+    with connect_to_debuglink() as debug:
         debug.watch_layout(True)
 
         # "backup contains XXX words"
@@ -764,7 +764,7 @@ def allow_unsafe() -> None:
 
 def get_debug_state() -> Dict[str, Any]:
     # We need to connect on UDP not to interrupt any bridge sessions
-    with connect_to_debuglink(needs_udp=True) as debug:
+    with connect_to_debuglink() as debug:
         debug_state = debug.state()
         debug_state_dict: Dict[str, Any] = {}
         for key in dir(debug_state):
@@ -789,7 +789,7 @@ class ScreenContent(TypedDict):
 
 
 def get_screen_content() -> ScreenContent:
-    with connect_to_debuglink(needs_udp=True) as debug:
+    with connect_to_debuglink() as debug:
         layout = debug.read_layout()
         title = layout.title()
         body = layout.text_content()


### PR DESCRIPTION
May fix https://github.com/trezor/trezor-suite/pull/14568:

- allow for `internal` device handling even when the `node` bridge is running - using `UDP` communication with the emulator, so it does not interfere with the running bridge