### PR TITLE
chore(ci): update poetry install params

### DIFF
--- a/.github/workflows/check-validation.yml
+++ b/.github/workflows/check-validation.yml
@@ -13,7 +13,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
 
       - name: "Install poetry"
-        run: nix-shell --run "poetry install"
+        run: nix-shell --run "poetry install --no-root"
       - name: Run style check
         run: nix-shell --run "poetry run make style_check"
       - name: Run code check

--- a/docker/Dockerfile-debian
+++ b/docker/Dockerfile-debian
@@ -42,7 +42,7 @@ WORKDIR /trezor-user-env
 
 # Install Python dependencies using poetry
 RUN poetry cache clear --all pypi
-RUN poetry install --no-dev --no-root
+RUN poetry install --no-root --without dev
 
 # Execute scripts and clean up
 RUN ./src/binaries/firmware/bin/download.sh


### PR DESCRIPTION
resolve https://github.com/trezor/trezor-user-env/issues/269

fixup 1:
also turns out `--no-dev` is also [deprecated](https://github.com/trezor/trezor-user-env/actions/runs/11255274404/job/31294471939) :)

```
The `--no-dev` option is deprecated, use the `--only main` notation instead.
```

fixup 2:
it should be `--without dev` [docs](https://python-poetry.org/docs/cli/)

fixup 3:
turns out dev is required by  validation CI :)