### PR TITLE
fix: emulator.get_debug_state response

### DIFF
--- a/src/dashboard/js/index.js
+++ b/src/dashboard/js/index.js
@@ -162,6 +162,7 @@ const app = createApp({
 
             if (
                 "response" in dataObject &&
+                typeof dataObject.response === 'string' &&
                 dataObject.response.includes("Emulator downloaded")
             ) {
                 this.downloadMessage = "";

--- a/src/emulator.py
+++ b/src/emulator.py
@@ -909,15 +909,18 @@ def get_debug_state() -> Dict[str, Any]:
         debug_state_dict: Dict[str, Any] = {}
         for key in dir(debug_state):
             val = getattr(debug_state, key)
-            # Not interested in private attributes and non-JSON fields (bytes)
+            # Not interested in private or uppercase attributes
             if key.startswith("__") or key[0].isupper():
                 continue
+            # Not interested in methods
+            if callable(val):
+                continue
+            # Transforming bytes to string
             if isinstance(val, bytes):
                 try:
                     val = val.decode("utf-8")
                 except UnicodeDecodeError:
                     val = val.hex()
-
             debug_state_dict[key] = val
 
         return debug_state_dict
@@ -940,9 +943,9 @@ def get_screen_content() -> ScreenContent:
 if __name__ == "__main__":
     # read_and_confirm_mnemonic()
     # read_and_confirm_mnemonic_t3t1()
-    read_and_confirm_shamir_mnemonic_t3t1(3, 2)
+    # read_and_confirm_shamir_mnemonic_t3t1(3, 2)
     # read_and_confirm_shamir_mnemonic_t2t1(3, 2)
-    # state = get_debug_state()
-    # print("state", state)
+    state = get_debug_state()
+    print("state", state)
     # screen = get_screen_content()
     # print("screen", screen)


### PR DESCRIPTION
fixing problem 1:
`get_debug_state` tries to serialize non buffer fields/keys (1 indent missing)
edit: after further testing this change can be tricky. 
DebugLinkState may contain some other filed types not only bytes (like int for example) but in the same time they might be complex and not serializable.
see thp state:

<DebugLinkState: {'mnemonic_secret': b'all all all all all all all all all all all all', 'passphrase_protection': False, 'reset_entropy': b'', 'mnemonic_type': <BackupType.Bip39: 0>, 'tokens': ['{', '"component"', ': ', '"SimplePage"', ', ', '"active_page"', ': ', '0', ', ', '"page_count"', ': ', '2', ', ', '"content"', ': ', '{', '"component"', ': ', '"AddressDetails"', ', ', '"qr_code"', ': ', '{', '"component"', ': ', '"Frame"', ', ', '"title"', ': ', '{', '"component"', ': ', '"Label"', ', ', '"text"', ': ', '"Scan QR code to pair"', '}', ', ', '"content"', ': ', '{', '"component"', ': ', '"Qr"', ', ', '"text"', ': ', '""', '}', ', ', '"button"', ': ', '{', '"component"', ': ', '"Button"', ', ', '"icon"', ': ', 'true', '}', '}', '}', '}'], 'thp_pairing_code_entry_code': 417041}>


fixing problem 2:
UI client assumes that `dataObject.response` is a string but in case of debug state it is an object

example: send JSON to server
```
{"type": "emulator-get-debug-state"}
```