### PR TITLE
feat: support starting emulator from a custom firmware branch

### DIFF
--- a/docs/controller.md
+++ b/docs/controller.md
@@ -42,6 +42,16 @@
     - **output_to_logfile**: `bool` (default=True) whether the debug output should go to a logfile - otherwise it goes to stdout
     - **save_screenshots**: `bool` (default=False) whether to save screenshots to enable calling **emulator-get-screenshot**
 
+- **emulator-start-from-branch**
+  - **action**: downloads latest emulators for a specified firmware branch and runs it
+  - **arguments**:
+    - **branch**: `str` exact name of the firmware branch
+    - **model**: `str` which emulator it is - `["T1B1", "T2T1", "T2B1", "T3T1", "T3W1"]`
+    - **btc_only**: `bool` (default=False) whether to get btc-only version of the emulator
+    - **wipe**: `bool` (default=False) whether to delete the emulator profile before starting it
+    - **output_to_logfile**: `bool` (default=True) whether the debug output should go to a logfile - otherwise it goes to stdout
+    - **save_screenshots**: `bool` (default=False) whether to save screenshots to enable calling **emulator-get-screenshot**
+
 - **emulator-stop**
   - **action**: stop the emulator
 

--- a/src/controller.py
+++ b/src/controller.py
@@ -225,6 +225,34 @@ class ResponseGetter:
             if wipe:
                 response_text += " and wiped to be empty"
             return {"response": response_text}
+        elif self.command == "emulator-start-from-branch":
+            branch = self.request_dict["branch"]
+            model = self.request_dict["model"]
+            if not model:
+                return {
+                    "success": False,
+                    "error": "Model must be supplied for the emulator to start",
+                }
+            binaries.check_model(model)
+            btc_only = self.request_dict.get("btc_only", False)
+            wipe = self.request_dict.get("wipe", False)
+            output_to_logfile = self.request_dict.get("output_to_logfile", True)
+            save_screenshots = self.request_dict.get("save_screenshots", False)
+            if model != PREV_RUNNING_MODEL:
+                wipe = True
+            PREV_RUNNING_MODEL = model
+            emulator.start_from_branch(
+                branch=branch,
+                model=model,
+                btc_only=btc_only,
+                wipe=wipe,
+                output_to_logfile=output_to_logfile,
+                save_screenshots=save_screenshots,
+            )
+            response_text = f"Emulator downloaded from branch {branch} and started"
+            if wipe:
+                response_text += " and wiped to be empty"
+            return {"response": response_text}
         elif self.command == "emulator-stop":
             emulator.stop()
             return {"response": "Emulator stopped"}

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -168,18 +168,9 @@
                     <input
                         type="text"
                         placeholder="Full emulator URL. Do not forget to specify correct model"
-                        style="width: 50%"
+                        style="width: 40%"
                         v-model="emulatorUrl.url"
                     />
-                    <select v-model="emulatorUrl.type">
-                        <option
-                            v-for="option in emulatorUrl.typeChoices"
-                            :key="option"
-                            :value="option"
-                        >
-                            {{ option }}
-                        </option>
-                    </select>
                     <select v-model="emulatorUrl.model">
                         <option
                             v-for="(details, model) in emulators.versions"
@@ -192,11 +183,42 @@
                     <button class="positive" @click="emulatorStartFromUrl();">
                         Start from URL
                     </button>
-
                 </div>
 
-                <div class="user-info" v-if="emulatorUrl.downloadMessage">
-                    {{ emulatorUrl.downloadMessage }}
+                <div>
+                    <input
+                        type="text"
+                        placeholder="Firmware branch. Do not forget to specify correct model"
+                        style="width: 30%"
+                        v-model="emulatorBranch.branch"
+                    />
+                    <select v-model="emulatorBranch.model">
+                        <option
+                            v-for="(details, model) in emulators.versions"
+                            :value="model"
+                            :key="model"
+                        >
+                            {{ details.header }}
+                        </option>
+                    </select>
+                        <input
+                        id="emulatorBtcOnly"
+                        type="checkbox"
+                        v-model="emulatorBranch.btcOnly"
+                    />
+                    <label
+                        class="underlined"
+                        title="Use BTC-only version of the emulator."
+                        for="emulatorBtcOnly"
+                        >BTC-only</label
+                    >
+                    <button class="positive" @click="emulatorStartFromBranch();">
+                        Start from branch
+                    </button>
+                </div>
+
+                <div class="user-info" v-if="emulatorDownloadMessage">
+                    {{ emulatorDownloadMessage }}
                 </div>
 
                 <hr />

--- a/src/dashboard/js/index.js
+++ b/src/dashboard/js/index.js
@@ -19,27 +19,22 @@ const app = createApp({
                     T1B1: {
                         header: "Trezor One",
                         versions: [],
-                        selected: "",
                     },
                     T2T1: {
                         header: "Trezor T",
                         versions: [],
-                        selected: "",
                     },
                     T2B1: {
                         header: "Trezor Safe 3",
                         versions: [],
-                        selected: "",
                     },
                     T3T1: {
                         header: "Trezor Safe 5",
                         versions: [],
-                        selected: "",
                     },
                     T3W1: {
                         header: "T3W1",
                         versions: [],
-                        selected: "",
                     },
                 },
                 wipeDevice: false,
@@ -50,11 +45,11 @@ const app = createApp({
             },
             emulatorUrl: {
                 url: "",
-                model: "T2T1",
+                model: "",
             },
             emulatorBranch: {
                 branch: "",
-                model: "T2T1",
+                model: "",
                 btcOnly: false,
             },
             emulatorDownloadMessage: "",
@@ -102,7 +97,19 @@ const app = createApp({
             }
         });
     },
+    watch: {
+        'emulatorUrl.url': function (newUrl) {
+            this.updateModelFromUrl(newUrl);
+        }
+    },
     methods: {
+        updateModelFromUrl(url) {
+            Object.keys(this.emulators.versions).forEach((model) => {
+                if (url.toLowerCase().includes(model.toLowerCase())) {
+                    this.emulatorUrl.model = model;
+                }
+            });
+        },
         setupWebSocket() {
             this.ws = new WebSocket(websocketUrl);
 
@@ -273,13 +280,17 @@ const app = createApp({
             });
         },
         emulatorStartFromUrl() {
-            let url = this.emulatorUrl.url;
+            const url = this.emulatorUrl.url;
             if (!url) {
                 this.showNotification("URL is empty!", true);
                 return;
             }
 
             const model = this.emulatorUrl.model;
+            if (!model) {
+                this.showNotification("Model is empty!", true);
+                return;
+            }
 
             this.sendMessage({
                 type: "emulator-start-from-url",
@@ -301,6 +312,10 @@ const app = createApp({
             }
 
             const model = this.emulatorBranch.model;
+            if (!model) {
+                this.showNotification("Model is empty!", true);
+                return;
+            }
 
             this.sendMessage({
                 type: "emulator-start-from-branch",

--- a/src/dashboard/js/index.js
+++ b/src/dashboard/js/index.js
@@ -50,11 +50,14 @@ const app = createApp({
             },
             emulatorUrl: {
                 url: "",
-                typeChoices: ["Custom link"],
-                type: "Custom link",
                 model: "T2T1",
-                downloadMessage: "",
             },
+            emulatorBranch: {
+                branch: "",
+                model: "T2T1",
+                btcOnly: false,
+            },
+            emulatorDownloadMessage: "",
             emulatorCommands: {
                 seed: "",
                 shamirShares: 3,
@@ -162,6 +165,7 @@ const app = createApp({
                         "Some error happened, please look into Log below.",
                         true
                     );
+                    this.emulatorDownloadMessage = "";
                 }
             }
 
@@ -170,7 +174,7 @@ const app = createApp({
                 typeof dataObject.response === 'string' &&
                 dataObject.response.includes("Emulator downloaded")
             ) {
-                this.downloadMessage = "";
+                this.emulatorDownloadMessage = "";
             }
 
             this.logEvent(`Response received: ${event.data}`, color);
@@ -286,7 +290,29 @@ const app = createApp({
                 save_screenshots: this.emulators.screenshotMode,
             });
 
-            this.downloadMessage =
+            this.emulatorDownloadMessage =
+                "Emulator started downloading, it may take a while...";
+        },
+        emulatorStartFromBranch() {
+            let branch = this.emulatorBranch.branch;
+            if (!branch) {
+                this.showNotification("Branch is empty!", true);
+                return;
+            }
+
+            const model = this.emulatorBranch.model;
+
+            this.sendMessage({
+                type: "emulator-start-from-branch",
+                branch,
+                model,
+                btc_only: this.emulatorBranch.btcOnly,
+                wipe: this.emulators.wipeDevice,
+                output_to_logfile: this.emulators.outputToLogfile,
+                save_screenshots: this.emulators.screenshotMode,
+            });
+
+            this.emulatorDownloadMessage =
                 "Emulator started downloading, it may take a while...";
         },
         reflectBackgroundSituationInGUI(dataObject) {


### PR DESCRIPTION
It is possible to specify firmware branch and we will try to find and start the specified emulator model from that branch.

Emulators are downloaded from `https://data.trezor.io/dev/firmware/emu-branches` dir - connected with https://github.com/trezor/trezor-firmware/pull/4358

NOTE: emulators for `arm` are not being built, so this feature is `Linux`-only ... but as CI is running on `Linux`, everybody can use it there (for automated `Suite` tests)