### PR TITLE
chore: add datetime at the start of all prints into console

### DIFF
--- a/src/helpers.py
+++ b/src/helpers.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from datetime import datetime
 from pathlib import Path
 
 from termcolor import colored  # type: ignore
@@ -27,7 +28,8 @@ logging.basicConfig(
 
 def log(text: str, color: str = "blue") -> None:
     logging.info(text)
-    print(colored(text, color))
+    now = datetime.now().strftime("%Y-%m-%d %H:%M:%S:%f")
+    print(colored(f"{now} - {text}", color))
 
 
 def physical_trezor() -> bool:


### PR DESCRIPTION
So that it is easier to see when things are happening from looking at console/docker logs - for troubleshooting purposes