### PR TITLE
fix: download and patch fw binaries on nixos

### DIFF
--- a/src/binaries/firmware/bin/download.sh
+++ b/src/binaries/firmware/bin/download.sh
@@ -60,8 +60,14 @@ files=(
   "T3T1/trezor-emu-core-T3T1-v2.8.7${suffix}"
 )
 
-for file in "${files[@]}"; do
-  wget "${BASE_EMU_URL}/${file}" || true
+for file_path in "${files[@]}"; do
+  file=$( echo ${file_path##*/} )
+  if [ -e $file ]
+  then
+    echo "${file} already exists. skipping..."
+  else
+    wget "${BASE_EMU_URL}/${file_path}" || true
+  fi
 done
 
 # download emulator from main

--- a/src/binaries/firmware/bin/patch-bin.sh
+++ b/src/binaries/firmware/bin/patch-bin.sh
@@ -6,6 +6,12 @@ echo "System architecture: $SYSTEM_ARCH"
 # Use the first argument as BINARY_DIR if provided; otherwise, default to './'
 BINARY_DIR="${1:-./}"
 
+# ./src/binaries/firmware/bin/patch-bin.sh ./src/binaries/firmware/bin/
+if [ -n "$IN_NIX_SHELL" ]; then
+    nix-shell --run "autoPatchelf ${BINARY_DIR}trezor-emu-*"
+    exit
+fi
+
 if [[ "$SYSTEM_ARCH" == "x86_64" ]]; then
     INTERPRETER_DEFAULT="/lib64/ld-linux-x86-64.so.2"
 elif [[ "$SYSTEM_ARCH" == "aarch64" || "$SYSTEM_ARCH" == "arm64" ]]; then


### PR DESCRIPTION
i had it stashed for a while now and used it only locally

im running user-env natively on nixos and having some issues [since the configuration changed](https://github.com/trezor/trezor-user-env/commit/4cafe457980ce3d17f6c603dfde61a92e7ed6461)

1. dowloading binaries produces copies instead of override existing file. Wtih this fix it will skip dowloading
2. patching binaries does not work, the process doesnt throw any error but patched binary cannot be started