### PR TITLE
chore: add release 2.8.9 emulators

### DIFF
--- a/src/binaries/firmware/bin/download.sh
+++ b/src/binaries/firmware/bin/download.sh
@@ -45,6 +45,7 @@ files=(
   "T2T1/trezor-emu-core-T2T1-v2.8.1${suffix}"
   "T2T1/trezor-emu-core-T2T1-v2.8.7${suffix}"
   "T2T1/trezor-emu-core-T2T1-v2.8.8${suffix}"
+  "T2T1/trezor-emu-core-T2T1-v2.8.9${suffix}"
   # T2B1
   "T2B1/trezor-emu-core-T2B1-v2.6.3${suffix}"
   "T2B1/trezor-emu-core-T2B1-v2.6.4${suffix}"
@@ -52,12 +53,14 @@ files=(
   "T2B1/trezor-emu-core-T2B1-v2.7.2${suffix}"
   "T2B1/trezor-emu-core-T2B1-v2.8.0${suffix}"
   "T2B1/trezor-emu-core-T2B1-v2.8.7${suffix}"
+  "T2B1/trezor-emu-core-T2B1-v2.8.9${suffix}"
   # T3T1
   "T3T1/trezor-emu-core-T3T1-v2.7.2${suffix}"
   "T3T1/trezor-emu-core-T3T1-v2.8.0${suffix}"
   "T3T1/trezor-emu-core-T3T1-v2.8.1${suffix}"
   "T3T1/trezor-emu-core-T3T1-v2.8.3${suffix}"
   "T3T1/trezor-emu-core-T3T1-v2.8.7${suffix}"
+  "T3T1/trezor-emu-core-T3T1-v2.8.9${suffix}"
 )
 
 for file_path in "${files[@]}"; do


### PR DESCRIPTION
Testing image with new emulators: ghcr.io/trezor/trezor-user-env:6553b975b5fc57193af9dd2c6b5df76c025528bf