### PR TITLE
Show commit hash of started emulator

### DIFF
--- a/docs/controller.md
+++ b/docs/controller.md
@@ -32,6 +32,7 @@
     - **wipe**: `bool` (default=False) whether to delete the emulator profile before starting it
     - **output_to_logfile**: `bool` (default=True) whether the debug output should go to a logfile - otherwise it goes to stdout
     - **save_screenshots**: `bool` (default=False) whether to save screenshots to enable calling **emulator-get-screenshot**
+    - **return_features**: `bool` (default=False) whether to call get-features
 
 - **emulator-start-from-url**
   - **action**: downloads emulator from specified URL and runs it

--- a/src/controller.py
+++ b/src/controller.py
@@ -185,20 +185,34 @@ class ResponseGetter:
             wipe = self.request_dict.get("wipe", False)
             output_to_logfile = self.request_dict.get("output_to_logfile", True)
             save_screenshots = self.request_dict.get("save_screenshots", False)
+            return_features = self.request_dict.get("return_features", False)
             if model != PREV_RUNNING_MODEL:
                 wipe = True
             PREV_RUNNING_MODEL = model
-            emulator.start(
+            features = emulator.start(
                 version=version,
                 model=model,
                 wipe=wipe,
                 output_to_logfile=output_to_logfile,
                 save_screenshots=save_screenshots,
+                return_features=return_features,
             )
             response_text = f"Emulator version {version} ({model}) started"
             if wipe:
                 response_text += " and wiped to be empty"
-            return {"response": response_text}
+
+            features_res = {}
+            if return_features and features:
+                log(f"Features: {features}")
+                features_res["revision"] = (
+                    features.revision.hex() if features.revision else "",
+                )
+
+            response = {
+                "response": response_text,
+                "features": features_res,
+            }
+            return {"response": response}
         elif self.command == "emulator-start-from-url":
             url = self.request_dict["url"]
             model = self.request_dict["model"]

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -160,6 +160,18 @@
                         >Screenshot mode</label
                     >
                     <br />
+                    <input
+                        id="emulatorReturnFeatures"
+                        type="checkbox"
+                        v-model="emulators.returnFeatures"
+                    />
+                    <label
+                        class="underlined"
+                        title="WIll log features and return the revision."
+                        for="emulatorReturnFeatures"
+                        >Return features</label
+                    >
+                    <br />
                 </div>
 
                 <hr />

--- a/src/dashboard/js/index.js
+++ b/src/dashboard/js/index.js
@@ -39,6 +39,7 @@ const app = createApp({
                 },
                 wipeDevice: false,
                 screenshotMode: false,
+                returnFeatures: false,
                 outputToLogfile: false,
                 status: "unknown",
                 statusColor: "black",
@@ -277,6 +278,7 @@ const app = createApp({
                 wipe: this.emulators.wipeDevice,
                 output_to_logfile: this.emulators.outputToLogfile,
                 save_screenshots: this.emulators.screenshotMode,
+                return_features: this.emulators.returnFeatures,
             });
         },
         emulatorStartFromUrl() {

--- a/src/emulator.py
+++ b/src/emulator.py
@@ -21,6 +21,7 @@ from trezorlib._internal.emulator import CoreEmulator, LegacyEmulator
 from trezorlib.client import TrezorClient
 from trezorlib.debuglink import DebugLink, TrezorClientDebugLink
 from trezorlib.exceptions import TrezorFailure
+from trezorlib.messages import Features
 from trezorlib.transport import Transport
 from trezorlib.transport.bridge import BridgeTransport
 from trezorlib.transport.udp import UdpTransport
@@ -140,7 +141,7 @@ def start_from_url(
     save_screenshots: bool = False,
     force_update: bool = False,
     force_name: str | None = None,
-) -> None:
+) -> Features | None:
     binaries.check_model(model)
 
     # Creating an identifier of emulator from this URL, so we have to
@@ -208,7 +209,7 @@ def start_from_branch(
     wipe: bool,
     output_to_logfile: bool = True,
     save_screenshots: bool = False,
-) -> None:
+) -> Features | None:
     emu_name = "trezor-emu-core"
     if binaries.IS_ARM:
         emu_name += binaries.ARM_IDENTIFIER
@@ -245,7 +246,8 @@ def start(
     wipe: bool,
     output_to_logfile: bool = True,
     save_screenshots: bool = False,
-) -> None:
+    return_features: bool = False,
+) -> Features | None:
     global VERSION_RUNNING
     global EMULATOR
     global MODEL_RUNNING
@@ -330,6 +332,10 @@ def start(
             dir_to_save = get_new_screenshot_dir()
             log(f"Saving screenshots to {dir_to_save}")
             debug.start_recording(str(dir_to_save))
+
+    if return_features:
+        return get_features()
+    return None
 
 
 def get_new_screenshot_dir() -> Path:
@@ -988,6 +994,11 @@ def apply_settings(
             safety_checks=safety_checks,
             experimental_features=experimental_features,
         )
+
+
+def get_features() -> Features:
+    with connect_to_client() as client:
+        return client.features
 
 
 def allow_unsafe() -> None:


### PR DESCRIPTION
Adds the possibility of logging the whole features object to tenv logs and also to return `revision` in the response ... so `Suite` can log it and/or work with it somehow

`return_features=true` needs to be set when calling  `emulator-start` command