### PR TITLE
feat: allow for enabling emulator animations

### DIFF
--- a/src/controller.py
+++ b/src/controller.py
@@ -185,6 +185,7 @@ class ResponseGetter:
             wipe = self.request_dict.get("wipe", False)
             output_to_logfile = self.request_dict.get("output_to_logfile", True)
             save_screenshots = self.request_dict.get("save_screenshots", False)
+            show_animations = self.request_dict.get("show_animations", False)
             if model != PREV_RUNNING_MODEL:
                 wipe = True
             PREV_RUNNING_MODEL = model
@@ -194,6 +195,7 @@ class ResponseGetter:
                 wipe=wipe,
                 output_to_logfile=output_to_logfile,
                 save_screenshots=save_screenshots,
+                show_animations=show_animations,
             )
             response_text = f"Emulator version {version} ({model}) started"
             if wipe:
@@ -212,6 +214,7 @@ class ResponseGetter:
             wipe = self.request_dict.get("wipe", False)
             output_to_logfile = self.request_dict.get("output_to_logfile", True)
             save_screenshots = self.request_dict.get("save_screenshots", False)
+            show_animations = self.request_dict.get("show_animations", False)
             if model != PREV_RUNNING_MODEL:
                 wipe = True
             PREV_RUNNING_MODEL = model
@@ -221,6 +224,7 @@ class ResponseGetter:
                 wipe=wipe,
                 output_to_logfile=output_to_logfile,
                 save_screenshots=save_screenshots,
+                show_animations=show_animations,
             )
             response_text = f"Emulator downloaded from {url} and started"
             if wipe:
@@ -249,6 +253,7 @@ class ResponseGetter:
                 wipe=wipe,
                 output_to_logfile=output_to_logfile,
                 save_screenshots=save_screenshots,
+                show_animations=show_animations,
             )
             response_text = f"Emulator downloaded from branch {branch} and started"
             if wipe:

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -120,6 +120,18 @@
 
                 <div>
                     <input
+                        id="animations"
+                        type="checkbox"
+                        v-model="emulators.animations"
+                    />
+                    <label
+                        class="underlined"
+                        title="Animations will be turned on."
+                        for="animations"
+                        >Show animations</label
+                    >
+                    <br />
+                    <input
                         id="wipeDevice"
                         type="checkbox"
                         v-model="emulators.wipeDevice"

--- a/src/dashboard/js/index.js
+++ b/src/dashboard/js/index.js
@@ -39,6 +39,7 @@ const app = createApp({
                 },
                 wipeDevice: false,
                 screenshotMode: false,
+                animations: false,
                 outputToLogfile: false,
                 status: "unknown",
                 statusColor: "black",
@@ -277,6 +278,7 @@ const app = createApp({
                 wipe: this.emulators.wipeDevice,
                 output_to_logfile: this.emulators.outputToLogfile,
                 save_screenshots: this.emulators.screenshotMode,
+                show_animations: this.emulators.animations,
             });
         },
         emulatorStartFromUrl() {
@@ -299,6 +301,7 @@ const app = createApp({
                 wipe: this.emulators.wipeDevice,
                 output_to_logfile: this.emulators.outputToLogfile,
                 save_screenshots: this.emulators.screenshotMode,
+                show_animations: this.emulators.animations,
             });
 
             this.emulatorDownloadMessage =
@@ -325,6 +328,7 @@ const app = createApp({
                 wipe: this.emulators.wipeDevice,
                 output_to_logfile: this.emulators.outputToLogfile,
                 save_screenshots: this.emulators.screenshotMode,
+                show_animations: this.emulators.animations,
             });
 
             this.emulatorDownloadMessage =

--- a/src/emulator.py
+++ b/src/emulator.py
@@ -142,6 +142,7 @@ def start_from_url(
     save_screenshots: bool = False,
     force_update: bool = False,
     force_name: str | None = None,
+    show_animations: bool = False,
 ) -> None:
     binaries.check_model(model)
 
@@ -200,6 +201,7 @@ def start_from_url(
         wipe=wipe,
         output_to_logfile=output_to_logfile,
         save_screenshots=save_screenshots,
+        show_animations=show_animations,
     )
 
 
@@ -210,6 +212,7 @@ def start_from_branch(
     wipe: bool,
     output_to_logfile: bool = True,
     save_screenshots: bool = False,
+    show_animations: bool = False,
 ) -> None:
     emu_name = "trezor-emu-core"
     if binaries.IS_ARM:
@@ -238,6 +241,7 @@ def start_from_branch(
         save_screenshots=save_screenshots,
         force_update=True,
         force_name=force_name,
+        show_animations=show_animations,
     )
 
 
@@ -247,6 +251,7 @@ def start(
     wipe: bool,
     output_to_logfile: bool = True,
     save_screenshots: bool = False,
+    show_animations: bool = False,
 ) -> None:
     global VERSION_RUNNING
     global EMULATOR
@@ -283,6 +288,7 @@ def start(
             emu_location,
             profile_dir=binaries.FIRMWARE_BIN_DIR,
             logfile=logfile,
+            disable_animation=not show_animations,
         )
     elif model == "T1B1":
         os.environ["TREZOR_OLED_SCALE"] = str(TREZOR_ONE_OLED_SCALE)


### PR DESCRIPTION
Fixes https://github.com/trezor/trezor-user-env/issues/299:
- allows for running the emulator with animations turned on ... useful e.g. for making videos