### PR TITLE
Pin old trezorlib commit && Fix the emulator status

### DIFF
--- a/docker/Dockerfile-debian
+++ b/docker/Dockerfile-debian
@@ -49,7 +49,7 @@ COPY ./poetry.lock /trezor-user-env/
 
 RUN poetry export -f requirements.txt --output requirements.txt --without-hashes --without dev
 RUN pip install -r requirements.txt
-RUN pip install "git+https://github.com/trezor/trezor-firmware.git@main#egg=trezor&subdirectory=python"
+RUN pip install "git+https://github.com/trezor/trezor-firmware.git@84cd0ba68123a7aa9471092ce5a87890439d0c3f#egg=trezor&subdirectory=python"
 
 # Copy the rest of the files
 COPY ./ /trezor-user-env


### PR DESCRIPTION
(hot) Fixes https://github.com/trezor/trezor-user-env/issues/316 ... instead of installing `trezorlib` from the `main` firmware branch, using a specific commit hash "pre-thp-changes"

Fixes https://github.com/trezor/trezor-user-env/issues/314 ... for some reason the `ps -ef` command started being truncated, which caused the emulator status not being correctly seen