### PR TITLE
chore: update trezorlib to the latest version, fixing THP pairing

### DIFF
--- a/docker/Dockerfile-debian
+++ b/docker/Dockerfile-debian
@@ -50,7 +50,7 @@ COPY ./poetry.lock /trezor-user-env/
 RUN poetry self add poetry-plugin-export
 RUN poetry export -f requirements.txt --output requirements.txt --without-hashes --without dev
 RUN pip install -r requirements.txt
-RUN pip install "git+https://github.com/trezor/trezor-firmware.git@022c7fe8bee9bd373c724bf88f618a75658de625#egg=trezor&subdirectory=python"
+RUN pip install "git+https://github.com/trezor/trezor-firmware.git@bfa3d82fb76ad24a341b27ee46c566db4693591d#egg=trezor&subdirectory=python"
 
 # Copy the rest of the files
 COPY ./ /trezor-user-env


### PR DESCRIPTION
Fixing THP pairing by bumping the trezorlib commit for the currently latest one