### PR TITLE
bind services to localhost and validate emulator download urls

### DIFF
--- a/src/binaries/node-bridge/modify_node_bin_js.sh
+++ b/src/binaries/node-bridge/modify_node_bin_js.sh
@@ -20,6 +20,7 @@ else
   exit 1
 fi
 
+# WARNING: this disables CORS origin validation - only safe on localhost
 # Replace if (isOriginAllowed) with if (true)
 if grep -q "if (isOriginAllowed)" "$1"; then
   sed -i 's/if (isOriginAllowed)/if (true)/g' "$1"

--- a/src/controller.py
+++ b/src/controller.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
     ResponseType = Union[NormalResponse, BackgroundCheckResponse]
 
 
-IP = "0.0.0.0"
+IP = "127.0.0.1"
 PORT = 9001
 LOG_COLOR = "blue"
 REGTEST_RPC = BTCJsonRPC(

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -11,7 +11,7 @@ from socketserver import ThreadingMixIn
 
 import helpers
 
-IP = "0.0.0.0"
+IP = "127.0.0.1"
 PORT = 9002
 HTML_DIR = Path(__file__).parent.parent / "src" / "dashboard"
 LOG_COLOR = "yellow"

--- a/src/emulator.py
+++ b/src/emulator.py
@@ -9,6 +9,7 @@ import threading
 import time
 import urllib.request
 from contextlib import contextmanager
+from urllib.parse import urlparse
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
@@ -162,6 +163,12 @@ def start_from_url(
     if not model_identifier:
         raise RuntimeError(f"Unknown model {model}")
     emu_path = binaries.USER_DOWNLOADED_DIR / f"{model_identifier}{emu_name}"
+
+    # Validate that the download URL points to a trusted domain
+    parsed = urlparse(url)
+    allowed_domains = ["data.trezor.io", "gitlab.com", "github.com"]
+    if not any(parsed.hostname == d or (parsed.hostname and parsed.hostname.endswith("." + d)) for d in allowed_domains):
+        raise ValueError(f"download url must be from a trusted domain, got: {parsed.hostname}")
 
     # Downloading only if it does not yet exist (or forced)
     if force_update or not emu_path.is_file():


### PR DESCRIPTION
## what this fixes

### network binding
the websocket controller (port 9001) and http dashboard (port 9002) were both bound to `0.0.0.0`, making them accessible to anyone on the network. the controller has no authentication, so on a shared wifi or cloud vm with a public ip, anyone could remotely trigger emulator downloads, wipe state, or shut down the service.

switched both to `127.0.0.1` so they're only reachable from the local machine.

### emulator url validation
`start_from_url()` downloads a binary from any url, marks it executable, and runs it. combined with the unauthenticated websocket, this was essentially remote code execution over the network.

added a domain allowlist — only `data.trezor.io`, `gitlab.com`, and `github.com` are accepted as download sources.

## testing
ran the dashboard and controller locally, confirmed they still work on localhost. tested that an invalid domain raises ValueError.