### PR TITLE
feat: add 'press yes' multiple times support

### DIFF
--- a/docs/controller.md
+++ b/docs/controller.md
@@ -68,6 +68,12 @@
 - **emulator-press-yes**
   - **action**: press yes button on the emulator
 
+- **emulator-press-yes-multiple**
+  - **action**: press the yes button multiple times with a delay between presses
+  - **arguments**:
+    - **count**: `int` (default=1)
+    - **delay**: `float` (default=0.1)
+
 - **emulator-press-no**
   - **action**: press no button on the emulator
 

--- a/src/controller.py
+++ b/src/controller.py
@@ -295,6 +295,11 @@ class ResponseGetter:
         elif self.command == "emulator-press-yes":
             emulator.press_yes()
             return {"response": "Pressed YES"}
+        elif self.command == "emulator-press-yes-multiple":
+            count = self.request_dict.get("count", 1)
+            delay = self.request_dict.get("delay", 0.1)
+            emulator.press_yes_multiple(count=count, delay=delay)
+            return {"response": f"Pressed YES {count} times"}
         elif self.command == "emulator-press-no":
             emulator.press_no()
             return {"response": "Pressed NO"}

--- a/src/emulator.py
+++ b/src/emulator.py
@@ -545,6 +545,17 @@ def press_yes() -> None:
         debug.press_yes()
 
 
+def press_yes_multiple(count: int, delay: float = 0.1) -> None:
+    try:
+        with connect_to_debuglink() as debug:
+            for _ in range(count):
+                debug.press_yes()
+                if delay > 0:
+                    time.sleep(delay)
+    except Exception as e:
+        log(f"Error when pressing YES multiple times: {repr(e)}", "red")
+
+
 def press_no() -> None:
     with connect_to_debuglink() as debug:
         debug.press_no()


### PR DESCRIPTION
  ## Description

  This PR introduces the  emulator-press-yes-multiple  command to the websocket controller. It allows automated tests (or external clients) to trigger multiple consecutive "YES" button
  clicks on the emulator with a configurable delay between each press.

  This is particularly useful for workflows that require dismissing or confirming multiple consecutive prompts on the device in a short span.

  ## Changes

  ### 1. Emulator Control ( src/emulator.py )

  • Added the  press_yes_multiple(count: int, delay: float = 0.1)  function:
      • Safely connects to the DebugLink.
      • Loops  count  times, triggering a  debug.press_yes()  on each iteration.
      • Introduces a custom delay (defaults to  0.1  seconds) between presses.


  ### 2. Websocket API Controller ( src/controller.py )

  • Registered the  emulator-press-yes-multiple  command to route requests to the new emulator function.
  • Parses the optional  count  and  delay  arguments from the websocket payload.

  ### 3. Documentation ( docs/controller.md )

  • Documented the new  emulator-press-yes-multiple  command and its options.
  ──────
  ## How to Test

  ### Websocket Test

  You can trigger the command by sending the following JSON payload to the websocket controller:

    {
      "type": "emulator-press-yes-multiple",
      "count": 5,
      "delay": 0.2
    }
    ```
