### PR TITLE
feat: redesign dashboard with Trezor Suite design language

### DIFF
--- a/src/controller.py
+++ b/src/controller.py
@@ -281,7 +281,14 @@ class ResponseGetter:
                 response_text += " and wiped to be empty"
             return {"response": response_text, "emulator_started": True}
         elif self.command == "emulator-stop":
+            # emulator.stop() clears MODEL_RUNNING, so read it first. If the
+            # T3W1 emulator auto-started the Tropic model server on launch
+            # (see emulator-start handler above), tear it down here too so
+            # stopping the emulator cleans up everything it spawned.
+            was_t3w1 = emulator.MODEL_RUNNING == "T3W1"
             emulator.stop()
+            if was_t3w1 and tropic_model.is_running():
+                tropic_model.stop()
             return {"response": "Emulator stopped"}
         elif self.command == "emulator-setup":
             emulator.setup_device(

--- a/src/dashboard/css/index.css
+++ b/src/dashboard/css/index.css
@@ -1,281 +1,1957 @@
+/* ============================================================
+   trezor-user-env — dashboard
+   Trezor Suite visual language. Maps to docs/dashboard-overview.md.
+   ============================================================ */
+
+@font-face {
+    font-family: "TT Satoshi";
+    src: url("../fonts/TTSatoshi-Medium.otf") format("opentype");
+    font-weight: 400;
+    font-style: normal;
+    font-display: swap;
+}
 @font-face {
     font-family: "TT Satoshi";
     src: url("../fonts/TTSatoshi-Medium.otf") format("opentype");
     font-weight: 500;
     font-style: normal;
+    font-display: swap;
 }
-
 @font-face {
     font-family: "TT Satoshi";
     src: url("../fonts/TTSatoshi-DemiBold.otf") format("opentype");
     font-weight: 600;
     font-style: normal;
+    font-display: swap;
 }
-
-* {
-    margin: 0;
-    padding: 0;
+@font-face {
     font-family: "TT Satoshi";
+    src: url("../fonts/TTSatoshi-DemiBold.otf") format("opentype");
+    font-weight: 700;
+    font-style: normal;
+    font-display: swap;
 }
 
-html,
-body {
-    width: 100%;
-    height: 100%;
-    background: #f4f4f4;
-    font-family: "TT Satoshi";
+@font-face {
+    font-family: "JetBrains Mono";
+    src: local("JetBrains Mono"), local("JetBrainsMono-Regular");
+    font-weight: 400;
+    font-style: normal;
+    font-display: swap;
 }
-
-.sections-container {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
-}
-
-section {
-    flex: 1 1 100%;
-    box-sizing: border-box;
-    padding: 22px;
-    margin: 24px;
-    border-radius: 6px;
-    background-color: rgb(255, 255, 255);
-}
-
-@media (min-width: 1025px) {
-    /* Adjust 600px to the breakpoint you desire */
-    section {
-        flex: 1 1 47%; /* Two sections per row on larger screens */
-    }
-}
-
-input {
-    margin: 6px;
-    padding: 12px;
-    border-radius: 8px;
-    border: solid 1px;
-    border-color: rgb(131, 130, 130);
-}
-select,
-input[type="submit"] {
-    border-radius: 5px;
-    padding: 2px;
-    cursor: pointer;
-    min-width: 170px;
-    margin: 0px 6px 14px 0px;
-    padding: 8px 12px;
+@font-face {
+    font-family: "JetBrains Mono";
+    src: local("JetBrains Mono Medium"), local("JetBrainsMono-Medium");
     font-weight: 500;
+    font-style: normal;
+    font-display: swap;
+}
+@font-face {
+    font-family: "JetBrains Mono";
+    src: local("JetBrains Mono SemiBold"), local("JetBrainsMono-SemiBold");
+    font-weight: 600;
+    font-style: normal;
+    font-display: swap;
 }
 
-select {
-    -webkit-appearance: none !important;
-    -moz-appearance: none !important;
-    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAUCAMAAACtdX32AAAAdVBMVEUAAAD///8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAhMdQaAAAAJ3RSTlMAAAECAwQGBwsOFBwkJTg5RUZ4eYCHkJefpaytrsXGy8zW3+Do8vNn0bsyAAAAYElEQVR42tXROwJDQAAA0Ymw1p9kiT+L5P5HVEi3qJn2lcPjtIuzUIJ/rhIGy762N3XaThqMN1ZPALsZPEzG1x8LrFL77DHBnEMxBewz0fJ6LyFHTPL7xhwzWYrJ9z22AqmQBV757MHfAAAAAElFTkSuQmCC);
-    background-position: 100%;
-    background-repeat: no-repeat;
-    padding: 12px;
-    border-radius: 8px;
-    font-size: medium;
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root,
+:root[data-theme="dark"] {
+    --sb-col: 220px;
+
+    --bg:          #0b0e10;
+    --bg-2:        #14171a;
+    --card:        #14171a;
+    --card-2:      #1a1d22;
+    --card-hover:  #1f232a;
+    --border:      #24282f;
+    --border-soft: #24282f80;
+    --text:        #eaecef;
+    --text-2:      #c6cad2;
+    --muted:       #8a919c;
+    --dim:         #5a6068;
+    --placeholder: #5f656e;
+
+    --primary:      #00b757;
+    --primary-2:    #00854d;
+    --primary-soft: #00b75714;
+    --primary-wash: #0d1814;
+
+    --red:          #ff6b5c;
+    --red-soft:     #ff6b5c14;
+    --amber:        #f0b14a;
+    --amber-soft:   #f0b14a14;
+    --blue:         #7db3ff;
+
+    --status-ok-bg:     #00b75714;
+    --status-ok-fg:     #00b757;
+    --status-err-bg:    #ff6b5c14;
+    --status-err-fg:    #ff6b5c;
+    --status-unk-bg:    #24282f;
+    --status-unk-fg:    #8a919c;
 }
 
-input[type="checkbox"] {
-    margin: 6px;
+:root[data-theme="light"] {
+    --bg:          #f4f5f7;
+    --bg-2:        #eaeef2;
+    --card:        #ffffff;
+    --card-2:      #f8f9fb;
+    --card-hover:  #f0f2f5;
+    --border:      #e2e5ea;
+    --border-soft: #e2e5ea80;
+    --text:        #0f1114;
+    --text-2:      #2d3138;
+    --muted:       #65727e;
+    --dim:         #a0a7b1;
+    --placeholder: #aab0ba;
+
+    --primary:      #00854d;
+    --primary-2:    #006a3d;
+    --primary-soft: #00854d12;
+    --primary-wash: #e8f5ee;
+
+    --red:          #c22a1a;
+    --red-soft:     #c22a1a12;
+    --amber:        #9c6a00;
+    --amber-soft:   #9c6a0012;
+    --blue:         #1d5cd8;
+
+    --status-ok-bg:     #00854d12;
+    --status-ok-fg:     #00854d;
+    --status-err-bg:    #c22a1a12;
+    --status-err-fg:    #c22a1a;
+    --status-unk-bg:    #e2e5ea;
+    --status-unk-fg:    #65727e;
 }
 
-button {
-    border: none;
-    color: white;
-    padding: 12px 25px;
-    text-align: center;
-    text-decoration: none;
-    min-width: 100px;
-    display: inline-block;
-    font-size: large;
-    border-radius: 50px;
-    margin: 8px;
-    cursor: pointer;
-    background-color: #27789b;
-    font-family: "TT Satoshi";
+html, body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: "TT Satoshi", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font-size: 14px;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+}
+body { min-height: 100vh; height: 100vh; overflow: hidden; }
+
+::selection { background: var(--primary-soft); color: var(--text); }
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--border); border-radius: 999px; border: 2px solid var(--bg); }
+::-webkit-scrollbar-thumb:hover { background: var(--muted); }
+
+button, select, input, textarea {
+    font: inherit;
+    color: inherit;
+    background: transparent;
+    border: 0;
+    outline: 0;
+}
+input::placeholder, textarea::placeholder { color: var(--placeholder); }
+a { color: var(--primary); text-decoration: none; }
+a:hover { text-decoration: underline; }
+code { font-family: "JetBrains Mono", ui-monospace, monospace; font-size: .92em; }
+
+.mono {
+    font-family: "JetBrains Mono", ui-monospace, monospace;
+    font-variant-numeric: tabular-nums;
 }
 
-.positive {
-    background-color: #0f6148;
+/* =========================================================
+   SHELL
+   ========================================================= */
+#app { height: 100vh; width: 100vw; }
+
+.shell {
+    height: 100vh;
+    display: grid;
+    grid-template-columns: var(--sb-col) 1fr;
+    grid-template-rows: 56px 1fr 256px;
+    /* row 1: topbar | row 2: sidebar+device | row 3: (empty)+log */
 }
 
-.negative {
-    background-color: #b43c3c;
-}
-
-.wipe-yes-no {
-    display: flex;
-    justify-content: space-between;
-}
-
-input[type="text"] {
-    min-width: 170px;
-    margin: 8px;
-    font-weight: 500;
-}
-
-textarea {
-    width: 100%;
-    min-height: 62px;
-    margin: 8px;
-}
-
-h3 {
-    font-weight: bold;
-    font-size: x-large;
-    margin-bottom: 10px;
-}
-
-hr {
-    margin: 10px 0px;
-}
-
-#ws-status {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.5);
-}
-
-#ws-status div {
-    background-color: white;
-    padding: 20px;
-}
-
-.explain-note {
-    font-size: 13px;
-    font-style: italic;
-}
-
-.underlined {
-    text-decoration: underline #000 dotted;
-    text-underline-offset: 3px;
-}
-
-.user-info {
-    font-weight: bold;
-    color: red;
-    font-size: 32px;
-}
-
-/* POPUP */
-
-.popup {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(0, 0, 0, 0.75);
-    z-index: 1000;
-}
-
-.popup-content {
-    position: relative;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    padding: 20px;
-    background: white;
-    border-radius: 20px;
-    text-align: center;
-    overflow-y: auto;
-}
-
-.whole-page-margins {
-    width: 95%;
-    height: 95%;
-}
-
-.half-page-margins {
-    width: 50%;
-}
-
-.close-button {
-    position: absolute;
-    top: -30px;
-    right: 0px;
-    font-size: 100px;
-    cursor: pointer;
-    font-weight: bold;
-    padding-right: 30px;
-    padding-bottom: 30px;
-    padding-left: 30px;
-}
-
-.red-border {
-    border: 15px solid red;
-}
-
-.green-border {
-    border: 15px solid green;
-}
-
-.waiting-for-response {
-    position: fixed;
-    top: 0;
-    width: 100%;
-    background-color: #333;
-    color: green;
-    font-size: xx-large;
-    font-weight: bold;
-    text-align: center;
-    padding: 10px 0;
-    z-index: 1000;
-}
-
-@media (prefers-color-scheme: dark) {
-    :root {
-        color-scheme: dark;
-    }
-
-    html,
-    body {
-        color: #a0a4ac;
-        background: #0c0d0e;
-    }
-
-    section,
-    .popup-content,
-    #ws-status div {
-        background-color: #151719;
-    }
-
-    h1,
-    h2,
-    h3,
-    h4 {
-        color: #e6e7e9;
-    }
-
-    input,
-    select {
-        background-color: #252628;
-    }
-}
-
-/* VNC viewer */
-.vnc-viewer {
+/* =========================================================
+   SIDEBAR
+   ========================================================= */
+.sidebar {
+    grid-column: 1;
+    grid-row: 2 / span 2;
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 12px;
     display: flex;
     flex-direction: column;
-    flex-grow: 1;
-
-    border-radius: 8px;
-    min-height: 600px;
+    padding: 12px;
+    overflow: visible;
+    margin: 16px 0 16px 16px;
+    position: relative;
+    z-index: 95;
+}
+/* Cover the 16px strip at viewport-left (outside the sidebar's left margin)
+   so the flyout sliding in behind the sidebar doesn't peek through it. */
+.sidebar::before {
+    content: '';
+    position: absolute;
+    top: -16px;
+    bottom: -16px;
+    left: -16px;
+    width: 16px;
+    background: var(--bg);
 }
 
-.vnc-toolbar {
+/* Sidebar main header — mirrors .card-head h3 on the right */
+.sb-main-head {
     display: flex;
-    justify-content: space-between;
     align-items: center;
+    gap: 10px;
+    padding: 4px 6px 10px;
+    margin-bottom: 10px;
+    border-bottom: 1px solid var(--border);
+}
+.sb-main-head h3 {
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: -.005em;
+    color: var(--text);
+    margin: 0;
+}
+
+/* Section sub-headers — mirror .cmd-sec h5 (uppercase, trailing line) */
+.sb-hd {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 0 6px;
+    margin-top: 14px;
+    margin-bottom: 5px;
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: .1em;
+    color: var(--muted);
+    position: relative;
+    cursor: default;
+}
+.sb-hd:hover .sb-legend-tip,
+.sb-legend-tip:hover {
+    opacity: 1;
+    transform: translateY(-50%) translateX(0);
+}
+.sb-main-head + .sb-hd { margin-top: 0; }
+.sb-hd::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: var(--border);
+}
+.sb-hd-info { margin-left: 0; }
+
+/* Module items */
+.sb-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 9px 11px;
+    margin-bottom: 1px;
+    border-radius: 8px;
+    color: var(--text-2);
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    background: transparent;
+    border: 0;
+    width: 100%;
+    text-align: left;
+    transition: background .12s, color .12s;
+}
+.sb-item:hover { background: var(--card-hover); color: var(--text); }
+.sb-item:disabled,
+.sb-item[aria-disabled="true"] { cursor: not-allowed; }
+.sb-item:disabled .sb-item-icon,
+.sb-item:disabled .sb-item-label,
+.sb-item[aria-disabled="true"] .sb-item-icon,
+.sb-item[aria-disabled="true"] .sb-item-label { opacity: .35; }
+.sb-item:disabled:hover,
+.sb-item[aria-disabled="true"]:hover { background: transparent; color: var(--text-2); }
+.sb-item:disabled .info-tip,
+.sb-item[aria-disabled="true"] .info-tip { pointer-events: all; cursor: help; }
+.sb-item .info-tip { width: 13px; height: 13px; }
+
+/* Sidebar info indicator — matches dot column alignment */
+.sb-info-tip {
+    flex-shrink: 0;
+    cursor: help;
+}
+.sb-info-tip::after {
+    right: auto;
+    left: calc(100% + 10px);
+    top: 50%;
+    bottom: auto;
+    transform: translateY(-50%) translateX(4px);
+    max-width: 200px;
+    font-size: 11px;
+    font-style: normal;
+    font-weight: 400;
+    z-index: 100;
+}
+.sb-info-tip:hover::after {
+    transform: translateY(-50%) translateX(0);
+}
+.sb-item.sb-item--on {
+    background: var(--primary-soft);
+    color: var(--primary);
+    box-shadow: inset 2px 0 0 var(--primary);
+}
+.sb-item-icon {
+    width: 16px; height: 16px; flex-shrink: 0;
+    stroke: currentColor; fill: none; stroke-width: 1.7;
+}
+.sb-item-text { flex: 1; display: flex; flex-direction: column; min-width: 0; overflow: hidden; }
+.sb-item-label { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.sb-item-version {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 10px;
+    opacity: 0.5;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    line-height: 1.3;
+}
+.sb-item-tag {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 10px;
+    color: var(--muted);
+    padding: 1px 7px;
+    border-radius: 999px;
+    background: var(--card-2);
+    border: 1px solid var(--border);
+    font-weight: 500;
+}
+.sb-item-dot {
+    width: 7px; height: 7px; border-radius: 999px; flex-shrink: 0;
+    background: var(--status-unk-fg);
+}
+.sb-item-dot--ok  { background: var(--primary); }
+.sb-item-dot--err { background: var(--red); }
+.sb-item-dot--unk { background: var(--dim); }
+
+.topbar {
+    grid-column: 1 / -1;
+    grid-row: 1;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 0 20px;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg);
+}
+.topbar-brand {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+.topbar-logo {
+    display: block;
+    height: 16px;
+    width: auto;
+    fill: var(--text);
+    flex-shrink: 0;
+}
+.topbar-brand-sep {
+    width: 1px;
+    height: 16px;
+    background: var(--border);
+    flex-shrink: 0;
+}
+.topbar-brand-name {
+    font-size: 13px;
+    font-weight: 500;
+    line-height: 1;
+    color: var(--muted);
+    letter-spacing: .01em;
+}
+.topbar-theme { color: var(--muted); }
+.topbar-theme:hover { color: var(--primary); }
+.topbar-theme svg { width: 14px; height: 14px; stroke: currentColor; fill: none; stroke-width: 2; }
+.topbar-crumb { display: flex; align-items: center; gap: 8px; font-size: 14px; min-width: 0; flex-wrap: wrap; }
+.topbar-crumb-title { font-weight: 600; letter-spacing: -.01em; }
+.topbar-crumb-sep { color: var(--dim); }
+.topbar-crumb-meta { color: var(--muted); }
+.topbar-spacer { flex: 1; }
+.topbar-actions { display: flex; gap: 8px; align-items: center; }
+
+/* Status pill — JS toggles .status-pill--ok / --error / --unknown */
+.status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-size: 11.5px;
+    font-weight: 600;
+    letter-spacing: .02em;
+    background: var(--status-unk-bg);
+    color: var(--status-unk-fg);
+    white-space: nowrap;
+}
+.status-pill::before {
+    content: "";
+    width: 6px; height: 6px;
+    border-radius: 999px;
+    background: currentColor;
+    flex-shrink: 0;
+}
+.status-pill--ok      { background: var(--status-ok-bg);  color: var(--status-ok-fg); }
+.status-pill--error   { background: var(--status-err-bg); color: var(--status-err-fg); }
+.status-pill--unknown { background: var(--status-unk-bg); color: var(--status-unk-fg); }
+
+/* =========================================================
+   BUTTONS
+   ========================================================= */
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 8px 14px;
+    border-radius: 9px;
+    background: var(--card);
+    border: 1px solid var(--border);
+    color: var(--text);
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background .12s, border-color .12s, color .12s, transform .08s;
+    font-family: inherit;
+}
+.btn:hover { background: var(--card-hover); border-color: var(--muted); }
+.btn:active { transform: scale(.98); }
+.btn:disabled { opacity: .5; cursor: not-allowed; }
+
+.btn--primary, .positive {
+    background: var(--primary);
+    color: #fff;
+    border-color: var(--primary);
+}
+.btn--primary:hover, .positive:hover {
+    background: var(--primary-2);
+    border-color: var(--primary-2);
+}
+
+.btn--danger, .negative {
+    color: var(--red);
+    border-color: transparent;
+    background: transparent;
+}
+.btn--danger:hover, .negative:hover {
+    background: var(--red-soft);
+    border-color: var(--red);
+}
+
+.btn--ghost { background: transparent; border-color: transparent; }
+.btn--ghost:hover { background: var(--card-hover); border-color: transparent; }
+
+.btn--sm { padding: 6px 10px; font-size: 12px; border-radius: 7px; }
+.btn--icon { width: 34px; height: 34px; padding: 7px; }
+.btn--icon.btn--sm { width: 30px; height: 30px; padding: 5px; }
+.btn--full { width: 100%; }
+.btn svg { width: 14px; height: 14px; stroke: currentColor; fill: none; stroke-width: 1.8; }
+
+/* =========================================================
+   CANVAS
+   ========================================================= */
+.canvas {
+    grid-column: 2;
+    grid-row: 2 / span 2;
+    padding: 16px 16px 16px 16px;
+    display: grid;
+    grid-template-columns: 1fr 325px;
+    grid-template-rows: minmax(0, 1fr) 240px;
+    gap: 16px;
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.card {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden; /* clips VNC iframe, log entries, etc. */
+}
+/* Commands card needs visible overflow so tooltips aren't clipped */
+.cmd-card { overflow: visible; }
+.card-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+}
+.card-head h3 {
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: -.005em;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+.card-head-live {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 2px 9px;
+    border-radius: 999px;
+    background: var(--primary-soft);
+    color: var(--primary);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: .04em;
+    text-transform: uppercase;
+}
+.card-head-live::before {
+    content: "";
+    width: 5px; height: 5px;
+    border-radius: 999px;
+    background: var(--primary);
+    animation: pulse 1.4s ease-in-out infinite;
+}
+@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: .4; } }
+
+.card-head-tag {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 10.5px;
+    color: var(--muted);
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: var(--card-2);
+    border: 1px solid var(--border);
+    font-weight: 500;
+}
+.card-head-tag--dim { opacity: 0.6; }
+.card-head-right { display: flex; gap: 4px; align-items: center; }
+
+/* ============ DEVICE CARD (VNC) ============ */
+.device-card { grid-column: 1; grid-row: 1; }
+
+.device-stage {
+    flex: 1;
+    min-height: 0;
+    position: relative;
+    display: grid;
+    place-items: center;
+    background: var(--bg-2);
+    overflow: hidden;
+}
+.device-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 14px;
+    color: var(--muted);
+    text-align: center;
+    padding: 32px;
+    max-width: 440px;
+}
+.device-empty-icon {
+    width: 64px; height: 64px;
+    border-radius: 14px;
+    background: var(--card);
+    border: 1px solid var(--border);
+    display: grid;
+    place-items: center;
+    color: var(--muted);
+}
+.device-empty-icon svg { width: 28px; height: 28px; stroke: currentColor; fill: none; stroke-width: 1.5; }
+.device-empty h4 { font-size: 15px; font-weight: 600; color: var(--text); letter-spacing: -.01em; }
+.device-empty p { font-size: 12.5px; line-height: 1.5; max-width: 38ch; }
+
+.device-empty-steps {
+    list-style: none;
+    padding: 0;
+    margin: 4px 0 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    max-width: 420px;
+    text-align: left;
+}
+.device-empty-steps li {
+    display: grid;
+    grid-template-columns: 24px 1fr;
+    gap: 12px;
+    align-items: start;
+    padding: 12px 14px;
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+}
+.device-empty-steps li > div {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+.device-empty-steps li > div b { font-size: 13px; color: var(--text); font-weight: 600; }
+.device-empty-steps li > div span { font-size: 12px; color: var(--muted); line-height: 1.5; }
+.device-empty-steps li > div .btn { width: fit-content; margin-top: 4px; }
+.device-empty-num {
+    width: 22px;
+    height: 22px;
+    border-radius: 999px;
+    background: var(--primary-soft);
+    color: var(--primary);
+    display: grid;
+    place-items: center;
+    font-size: 11px;
+    font-weight: 700;
 }
 
 .vnc-iframe {
+    width: 100%;
+    height: 100%;
+    border: 0;
+    background: #000;
+    display: block;
+}
+
+/* ============ COMMANDS CARD ============ */
+.cmd-card {
+    grid-column: 2;
+    grid-row: 1 / span 2;
+    /* Allow tooltips inside to escape the card boundary */
+    overflow: visible;
+}
+.cmd-body {
+    padding: 10px 12px;
     display: flex;
-    flex-grow: 1;
-    border: none;
+    flex-direction: column;
+    gap: 8px;
+    overflow: visible;
+    /* No scroll — everything must fit */
+}
+.cmd-sec h5 {
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: .1em;
+    color: var(--muted);
+    margin-bottom: 5px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.cmd-sec h5::after { content: ""; flex: 1; height: 1px; background: var(--border); }
+
+.cmd-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    width: 100%;
+    padding: 7px 11px;
+    border-radius: 9px;
+    background: var(--card-2);
+    border: 1px solid var(--border);
+    color: var(--text);
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    text-align: center;
+    transition: background .12s, border-color .12s, color .12s;
+    font-family: inherit;
+}
+.cmd-btn:hover { background: var(--card-hover); border-color: var(--muted); }
+.cmd-btn-kbd {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 10.5px;
+    color: var(--muted);
+    padding: 1px 6px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--bg-2);
+}
+/* Descriptor tag — looks like metadata, not a keyboard key (e.g. word count) */
+.cmd-btn-tag {
+    font-size: 11px;
+    color: var(--dim);
+    font-family: inherit;
+    font-weight: 400;
+    letter-spacing: .02em;
+}
+.cmd-btn--seed {
+    flex-direction: column;
+    gap: 4px;
+    padding-block: 10px;
+}
+.cmd-btn-seed-label {
+    font-weight: 500;
+    font-size: 13px;
+}
+.cmd-btn--seed .cmd-btn-tag {
+    font-size: 10.5px;
+    background: var(--bg-2);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 1px 7px;
+    color: var(--muted);
+}
+.cmd-btn--primary {
+    background: var(--primary);
+    color: #fff;
+    border-color: var(--primary);
+}
+.cmd-btn--primary:hover { background: var(--primary-2); border-color: var(--primary-2); }
+.cmd-btn--primary .cmd-btn-kbd {
+    color: rgba(255,255,255,.85);
+    border-color: rgba(255,255,255,.25);
+    background: rgba(255,255,255,.1);
+}
+.cmd-btn--danger { color: var(--red); }
+.cmd-btn--danger:hover { background: var(--red-soft); border-color: var(--red); }
+.cmd-btn--warn { color: var(--amber); }
+.cmd-btn--warn:hover { background: var(--amber-soft); border-color: var(--amber); color: var(--amber); }
+.cmd-btn--warn .info-tip { color: var(--amber); }
+.cmd-btn--ghost {
+    background: transparent;
+    border-color: transparent;
+    justify-content: flex-start;
+    padding: 7px 10px;
+    font-weight: 400;
+    color: var(--muted);
+}
+.cmd-btn--ghost:hover { background: var(--card-hover); color: var(--text); }
+
+.row2 { display: grid; grid-template-columns: 1fr 1fr; gap: 7px; }
+.row3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 7px; }
+
+/* dial (numeric) */
+.dial {
+    display: flex;
+    align-items: stretch;
+    border: 1px solid var(--border);
+    border-radius: 9px;
+    overflow: hidden;
+    background: var(--card-2);
+}
+.dial-label {
+    padding: 0 11px;
+    display: grid;
+    place-items: center;
+    color: var(--muted);
+    font-size: 10.5px;
+    text-transform: uppercase;
+    letter-spacing: .08em;
+    border-right: 1px solid var(--border);
+    font-weight: 600;
+    white-space: nowrap;
+}
+.dial-input {
+    flex: 1;
+    text-align: center;
+    padding: 7px 0;
+    font-family: "JetBrains Mono", monospace;
+    font-size: 12.5px;
+    color: var(--text);
+    font-weight: 500;
+    min-width: 0;
+    width: 100%;
+    background: transparent;
+    border: 0;
+}
+.dial-input:focus { color: var(--primary); }
+
+/* Shamir dials + action fused into one visual unit. */
+.shamir-group {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid var(--border);
+    border-radius: 9px;
+    background: var(--card-2);
+    overflow: visible;
+    margin-bottom: 10px;
+}
+/* Re-clip child corners since overflow:visible removes the group's own clipping */
+.shamir-group .shamir-dials { border-radius: 9px 9px 0 0; overflow: hidden; }
+.shamir-group > .cmd-btn:last-child { border-radius: 0 0 9px 9px; }
+.shamir-group .shamir-dials {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    border-bottom: 1px solid var(--border);
+}
+.shamir-group .shamir-dials .dial {
+    display: flex;
+    align-items: stretch;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    padding: 0;
+}
+.shamir-group .shamir-dials .dial + .dial {
+    border-left: 1px solid var(--border);
+}
+.shamir-group .shamir-dials .dial-stack {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 4px 0;
+    min-width: 0;
+}
+.shamir-group .shamir-dials .dial-label {
+    border-right: 0;
+    background: transparent;
+    font-size: 9.5px;
+    padding: 0;
+    line-height: 1.2;
+}
+.shamir-group .shamir-dials .dial-input {
+    padding: 0;
+    width: 100%;
+    font-size: 14px;
+    font-weight: 600;
+    text-align: center;
+    line-height: 1.2;
+    -moz-appearance: textfield;
+    appearance: textfield;
+}
+.shamir-group .shamir-dials .dial-input::-webkit-outer-spin-button,
+.shamir-group .shamir-dials .dial-input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+.dial-step {
+    width: 28px;
+    background: transparent;
+    border: 0;
+    color: var(--muted);
+    font-family: inherit;
+    font-size: 16px;
+    line-height: 1;
+    cursor: pointer;
+    transition: background .12s, color .12s;
+    padding: 0;
+}
+.dial-step:hover { background: var(--card-hover); color: var(--text); }
+.dial-step:active { background: var(--primary-soft); color: var(--primary); }
+.shamir-group > .cmd-btn {
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    width: 100%;
+}
+.shamir-group > .cmd-btn:hover {
+    background: var(--card-hover);
+    border-color: transparent;
+}
+
+/* form bits */
+.input, .select, .textarea {
+    width: 100%;
+    padding: 9px 13px;
+    /* Inputs use --bg (main bg) rather than --card-2 so they look recessed/editable
+       compared to buttons and toggles which sit at card-2 level. */
+    background: var(--bg);
+    border: 1px solid var(--muted);
+    border-radius: 9px;
+    color: var(--text);
+    font-size: 13px;
+    transition: border-color .12s, box-shadow .12s;
+    font-family: inherit;
+}
+.input:focus, .select:focus, .textarea:focus {
+    border-color: var(--primary);
+    box-shadow: 0 0 0 3px var(--primary-soft);
+}
+.input[type="number"] {
+    -moz-appearance: textfield;
+    appearance: textfield;
+}
+.input[type="number"]::-webkit-outer-spin-button,
+.input[type="number"]::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+}
+.textarea {
+    font-family: "JetBrains Mono", monospace;
+    min-height: 100px;
+    resize: vertical;
+    line-height: 1.55;
+    padding: 10px 13px;
+}
+.select {
+    appearance: none;
+    -webkit-appearance: none;
+    padding-right: 32px;
+    background-image:
+        linear-gradient(45deg, transparent 50%, var(--muted) 50%),
+        linear-gradient(-45deg, transparent 50%, var(--muted) 50%);
+    background-position:
+        calc(100% - 18px) 50%,
+        calc(100% - 13px) 50%;
+    background-size: 5px 5px;
+    background-repeat: no-repeat;
+}
+.field-label {
+    display: block;
+    font-size: 10.5px;
+    text-transform: uppercase;
+    letter-spacing: .1em;
+    color: var(--muted);
+    margin-bottom: 7px;
+    margin-top: 16px;
+    font-weight: 600;
+}
+.field-label:first-child { margin-top: 0; }
+.field-label-note {
+    color: var(--muted);
+    text-transform: none;
+    letter-spacing: 0;
+    font-weight: 400;
+    margin-left: 6px;
+}
+.field-hint { font-size: 11.5px; color: var(--muted); margin-top: 6px; line-height: 1.5; }
+.field-hint b { color: var(--text); }
+.field-hint code {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 11px;
+    background: var(--card-2);
+    padding: 2px 6px;
+    border-radius: 4px;
+    color: var(--text);
+    border: 1px solid var(--border);
+}
+
+/* ============ LOG CARD ============ */
+.log-card { grid-column: 1; grid-row: 2; position: relative; }
+.log-tools {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 14px;
+    border-bottom: 1px solid var(--border);
+    background: var(--card-2);
+    font-size: 12px;
+    flex-shrink: 0;
+}
+.log-tools-label { color: var(--muted); font-weight: 500; }
+.log-tools-spacer { flex: 1; }
+.log-tools-clear {
+    font-size: 12px;
+    color: var(--muted);
+    cursor: pointer;
+    padding: 3px 10px;
+    border-radius: 6px;
+    background: transparent;
+    border: 0;
+    font-family: inherit;
+    font-weight: 500;
+}
+.log-tools-clear:hover { color: var(--red); background: var(--red-soft); }
+
+.log-entries {
+    flex: 1;
+    overflow: auto;
+    padding: 4px 0;
+    font-family: "JetBrains Mono", ui-monospace, monospace;
+    font-size: 12px;
+    line-height: 1.6;
+}
+.log-entries > p {
+    padding: 3px 16px;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+.log-entries > p:hover { background: var(--card-2); }
+.log-empty {
+    padding: 24px 16px;
+    color: var(--muted);
+    font-family: "TT Satoshi", sans-serif;
+    font-size: 12.5px;
+    text-align: center;
+}
+
+.log-filters {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-wrap: wrap;
+}
+.log-filter {
+    padding: 3px 9px;
+    border: 0;
+    border-radius: 999px;
+    background: transparent;
+    color: var(--muted);
+    font-family: inherit;
+    font-size: 11px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background .12s, color .12s;
+}
+.log-filter:hover { color: var(--text); background: var(--card-2); }
+.log-filter.log-filter--on {
+    background: var(--primary-soft);
+    color: var(--primary);
+}
+
+.log-unseen-chip {
+    position: absolute;
+    left: 50%;
+    top: 52px;
+    transform: translateX(-50%);
+    padding: 5px 12px;
+    border-radius: 999px;
+    border: 1px solid var(--primary);
+    background: var(--card);
+    color: var(--primary);
+    font-family: inherit;
+    font-size: 11.5px;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 4px 12px -4px rgba(0,0,0,.3);
+    z-index: 2;
+    animation: slideIn .2s ease;
+}
+.log-unseen-chip:hover { background: var(--primary-soft); }
+@keyframes slideIn { from { opacity: 0; transform: translate(-50%, -6px); } to { opacity: 1; transform: translate(-50%, 0); } }
+
+/* =========================================================
+   FLYOUT (side panels for module configuration)
+   ========================================================= */
+.flyout-backdrop {
+    position: fixed;
+    top: 56px;
+    left: var(--sb-col, 220px);
+    right: 0;
+    bottom: 0;
+    background: rgba(0,0,0,.35);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity .22s;
+    z-index: 80;
+}
+:root[data-theme="light"] .flyout-backdrop { background: rgba(15,17,20,.18); }
+.flyout-backdrop--on { opacity: 1; pointer-events: auto; }
+
+.flyout {
+    position: fixed;
+    top: 72px;
+    left: -560px;
+    bottom: 16px;
+    width: 480px;
+    max-width: calc(100vw - var(--sb-col, 220px) - 24px);
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    box-shadow: 20px 20px 60px -20px rgba(0,0,0,.35);
+    z-index: 90;
+    transition: left .25s cubic-bezier(.2,.8,.2,1);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+.flyout--open { left: calc(var(--sb-col, 220px) + 4px); }
+html.no-fly-transition .flyout { transition: none !important; }
+.flyout--locked .flyout-body .btn,
+.flyout--locked .flyout-body .model,
+.flyout--locked .flyout-body .vitem,
+.flyout--locked .flyout-body .opt-tile,
+.flyout--locked .flyout-body .input,
+.flyout--locked .flyout-body .select,
+.flyout--locked .flyout-body .segmented button,
+.flyout--locked .flyout-body .disclosure {
+    pointer-events: none;
+    opacity: 0.55;
+}
+.flyout--locked .dl-banner { opacity: 1; pointer-events: auto; }
+.flyout-head {
+    padding: 18px 22px 12px;
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 14px;
+    flex-shrink: 0;
+}
+.flyout-head-title { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+.flyout-head h2 {
+    font-size: 18px;
+    font-weight: 600;
+    letter-spacing: -.01em;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+.flyout-head h2 .mono { color: var(--muted); font-size: 12.5px; font-weight: 400; }
+.flyout-head-desc {
+    font-size: 12.5px;
+    color: var(--muted);
+    max-width: 46ch;
+    line-height: 1.5;
+    margin-top: 3px;
+}
+.flyout-close {
+    width: 30px; height: 30px;
+    border-radius: 7px;
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+    color: var(--muted);
+    background: transparent;
+    border: 0;
+    flex-shrink: 0;
+}
+.flyout-close:hover { background: var(--card-2); color: var(--text); }
+.flyout-close svg { width: 16px; height: 16px; stroke: currentColor; fill: none; stroke-width: 2; }
+
+.flyout-body {
+    padding: 18px 22px;
+    overflow: auto;
+    flex: 1;
+}
+.flyout-actions {
+    margin-top: 20px;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+}
+
+/* models grid inside emulator flyout */
+.models {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 6px;
+    margin-top: 6px;
+}
+.model {
+    padding: 10px 6px;
+    border: 1px solid var(--border);
+    border-radius: 9px;
+    cursor: pointer;
+    text-align: center;
+    background: var(--card-2);
+    color: var(--text);
+    transition: border-color .12s, background .12s, color .12s;
+    font-family: inherit;
+    font-size: inherit;
+}
+.model:hover { border-color: var(--muted); }
+.model-id {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 10px;
+    color: var(--muted);
+    letter-spacing: .08em;
+    margin-bottom: 2px;
+}
+.model-name {
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: -.01em;
+}
+.model-type {
+    font-size: 10px;
+    color: var(--muted);
+    margin-top: 2px;
+}
+.model.model--selected {
+    border-color: var(--primary);
+    background: var(--primary-soft);
+    color: var(--primary);
+}
+.model.model--selected .model-id,
+.model.model--selected .model-type { color: var(--primary); }
+.model.model--running {
+    outline: 2px solid var(--primary);
+    outline-offset: -2px;
+}
+
+/* Launch-option tiles — same on-state aesthetic as selected model tile. */
+.opt-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 7px;
+    margin-top: 6px;
+}
+.opt-tile {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 9px 13px;
+    border: 1px solid var(--border);
+    border-radius: 9px;
+    background: var(--card-2);
+    color: var(--text);
+    cursor: pointer;
+    text-align: left;
+    user-select: none;
+    position: relative;
+    transition: background .12s, border-color .12s, color .12s;
+}
+.opt-tile:hover { border-color: var(--muted); }
+.opt-tile > input[type="checkbox"] {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+    width: 0; height: 0;
+}
+.opt-tile-name {
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: -.005em;
+}
+.opt-tile:has(input:checked) {
+    border-color: var(--primary);
+    background: var(--primary-soft);
+    color: var(--primary);
+}
+
+/* Toggle switch: pill track + sliding knob.
+   background-position moves the white circle left → right.
+   Both background-color and background-position transition smoothly. */
+.opt-tile:not(.opt-tile--inline)::after {
+    content: "";
+    display: block;
+    flex-shrink: 0;
+    width: 22px;
+    height: 13px;
+    border-radius: 999px;
+    background-color: transparent;
+    box-shadow: 0 0 0 1px var(--dim);
+    background-image: radial-gradient(circle closest-side, var(--dim) 100%, transparent 0);
+    background-size: 11px 11px;
+    background-repeat: no-repeat;
+    background-position: 1px center;
+    transition: background-color .2s ease, background-position .2s ease, box-shadow .2s ease;
+}
+.opt-tile:has(input:checked)::after {
+    background-color: var(--primary);
+    box-shadow: none;
+    background-image: radial-gradient(circle closest-side, #fff 100%, transparent 0);
+    background-position: 10px center;
+}
+
+/* Generic info-tip — small ⓘ icon with hover tooltip (tooltip below icon).
+   Safe to use anywhere; overflow:hidden on parent card is handled because the
+   tooltip expands downward and stays inside the card body. */
+.info-tip {
+    position: relative;
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+    display: grid;
+    place-items: center;
+    color: var(--muted);
+    cursor: help;
+    border-radius: 999px;
+}
+.info-tip svg {
+    width: 14px;
+    height: 14px;
+    stroke: currentColor;
+    fill: none;
+    stroke-width: 1.8;
+}
+.info-tip:hover { color: var(--text); }
+.info-tip::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    top: calc(100% + 8px);
+    right: -6px;
+    background: var(--card);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 7px;
+    padding: 7px 11px;
+    font-size: 11.5px;
+    font-weight: 500;
+    line-height: 1.4;
+    letter-spacing: 0;
+    text-transform: none;
+    width: max-content;
+    max-width: 240px;
+    white-space: normal;
+    box-shadow: 0 10px 28px -10px rgba(0,0,0,.45);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-4px);
+    transition: opacity .15s ease, transform .15s ease;
+    z-index: 10;
+}
+:root[data-theme="light"] .info-tip::after {
+    box-shadow: 0 10px 28px -10px rgba(16,18,21,.18);
+}
+.info-tip:hover::after {
+    opacity: 1;
+    transform: translateY(0);
+}
+.info-tip:not([data-tooltip])::after { display: none; }
+
+/* Sidebar legend tooltip — rich content (coloured dots) shown on hover.
+   Replaces the text-only `data-tooltip` pseudo-element for the Services header. */
+.sb-legend-tip {
+    position: absolute;
+    left: calc(100% + 10px);
+    top: 50%;
+    transform: translateY(-50%) translateX(4px);
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    background: var(--card);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 7px;
+    padding: 7px 11px;
+    font-size: 11px;
+    font-weight: 400;
+    line-height: 1.4;
+    letter-spacing: 0;
+    text-transform: none;
+    width: max-content;
+    max-width: 200px;
+    box-shadow: 0 10px 28px -10px rgba(0,0,0,.45);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity .15s ease, transform .15s ease;
+    z-index: 100;
+}
+:root[data-theme="light"] .sb-legend-tip {
+    box-shadow: 0 10px 28px -10px rgba(16,18,21,.18);
+}
+.info-tip:hover .sb-legend-tip {
+    opacity: 1;
+    transform: translateY(-50%) translateX(0);
+}
+.sb-legend-title {
+    font-weight: 500;
+    color: var(--text);
+    margin-bottom: 2px;
+}
+.sb-legend-row {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--text-2);
+}
+.sb-legend-dot {
+    width: 7px; height: 7px;
+    border-radius: 999px;
+    flex-shrink: 0;
+}
+.sb-legend-dot--ok  { background: var(--primary); }
+.sb-legend-dot--err { background: var(--red); }
+.sb-legend-dot--unk { background: var(--dim); }
+
+/* Button tooltip — shown above the button on hover via data-tooltip attribute */
+button[data-tooltip] { position: relative; }
+button[data-tooltip]::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    bottom: calc(100% + 8px);
+    left: 50%;
+    transform: translateX(-50%) translateY(4px);
+    background: var(--card);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 7px;
+    padding: 7px 11px;
+    font-size: 11.5px;
+    font-weight: 400;
+    line-height: 1.4;
+    letter-spacing: 0;
+    text-transform: none;
+    width: max-content;
+    max-width: 220px;
+    white-space: normal;
+    box-shadow: 0 10px 28px -10px rgba(0,0,0,.45);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity .15s ease 0s, transform .15s ease 0s;
+    z-index: 20;
+}
+:root[data-theme="light"] button[data-tooltip]::after {
+    box-shadow: 0 10px 28px -10px rgba(16,18,21,.18);
+}
+button[data-tooltip]:hover::after {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+    transition: opacity .15s ease .6s, transform .15s ease .6s;
+}
+button[data-tooltip][data-tooltip-pos="right"]::after {
+    left: auto;
+    right: 0;
+    transform: translateX(0) translateY(4px);
+}
+button[data-tooltip][data-tooltip-pos="right"]:hover::after {
+    transform: translateX(0) translateY(0);
+}
+
+/* Label tooltip — uses ::before so ::after stays free for the toggle switch */
+label[data-tooltip] { position: relative; }
+label[data-tooltip]::before {
+    content: attr(data-tooltip);
+    position: absolute;
+    bottom: calc(100% + 8px);
+    left: 50%;
+    transform: translateX(-50%) translateY(4px);
+    background: var(--card);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 7px;
+    padding: 7px 11px;
+    font-size: 11.5px;
+    font-weight: 400;
+    line-height: 1.4;
+    letter-spacing: 0;
+    text-transform: none;
+    width: max-content;
+    max-width: 220px;
+    white-space: normal;
+    box-shadow: 0 10px 28px -10px rgba(0,0,0,.45);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity .15s ease 0s, transform .15s ease 0s;
+    z-index: 20;
+}
+:root[data-theme="light"] label[data-tooltip]::before {
+    box-shadow: 0 10px 28px -10px rgba(16,18,21,.18);
+}
+label[data-tooltip]:hover::before {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+    transition: opacity .15s ease .6s, transform .15s ease .6s;
+}
+
+/* Info icon + hover tooltip (e.g. Screenshot mode detail). */
+.opt-tile-info {
+    position: relative;
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+    display: grid;
+    place-items: center;
+    color: var(--muted);
+    cursor: help;
+    border-radius: 999px;
+}
+.opt-tile-info svg {
+    width: 14px;
+    height: 14px;
+    stroke: currentColor;
+    fill: none;
+    stroke-width: 1.8;
+}
+.opt-tile:has(input:checked) .opt-tile-info { color: var(--primary); opacity: .85; }
+.opt-tile-info:hover { color: var(--text); }
+.opt-tile:has(input:checked) .opt-tile-info:hover { color: var(--primary); opacity: 1; }
+
+.opt-tile-info::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    bottom: calc(100% + 8px);
+    right: -6px;
+    background: var(--card);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 7px;
+    padding: 7px 11px;
+    font-size: 11.5px;
+    font-weight: 500;
+    line-height: 1.4;
+    letter-spacing: 0;
+    text-transform: none;
+    width: max-content;
+    max-width: 220px;
+    white-space: normal;
+    box-shadow: 0 10px 28px -10px rgba(0,0,0,.45);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(4px);
+    transition: opacity .15s ease, transform .15s ease;
+    z-index: 10;
+}
+:root[data-theme="light"] .opt-tile-info::after {
+    box-shadow: 0 10px 28px -10px rgba(16,18,21,.18);
+}
+.opt-tile-info:hover::after {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+/* bridge version list */
+.vlist { display: flex; flex-direction: column; gap: 4px; margin-top: 6px; }
+.vlist-divider {
+    font-size: 10.5px;
+    color: var(--dim);
+    text-transform: uppercase;
+    letter-spacing: .08em;
+    font-weight: 600;
+    padding: 10px 2px 4px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.vlist-divider::after { content: ""; flex: 1; height: 1px; background: var(--border); }
+
+.vgroup { margin-top: 10px; }
+.vgroup:first-child { margin-top: 0; }
+.vgroup-head {
+    font-size: 10.5px;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: .08em;
+    font-weight: 600;
+    margin-bottom: 4px;
+    padding-left: 2px;
+}
+.vitem {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 9px 12px;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+    background: var(--card-2);
+    font-size: 12.5px;
+    cursor: pointer;
+    font-family: inherit;
+    color: var(--text);
+    text-align: left;
+    width: 100%;
+}
+.vitem:hover { border-color: var(--muted); }
+.vitem:disabled { cursor: not-allowed; opacity: .55; }
+.vitem:disabled:hover { border-color: var(--border); }
+.vitem--selected:disabled { opacity: 1; }
+.vitem--selected {
+    border-color: var(--primary);
+    background: var(--primary-soft);
+    color: var(--primary);
+    font-weight: 600;
+}
+.vitem-name { font-family: "JetBrains Mono", monospace; }
+.vitem-badge {
+    font-size: 10px;
+    padding: 1px 7px;
+    border: 1px solid var(--primary);
+    border-radius: 999px;
+    color: var(--primary);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: .06em;
+}
+
+/* Disclosure button (subtle expander for optional sections) */
+.disclosure {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 9px 10px;
+    margin-top: 12px;
+    background: transparent;
+    border: 0;
+    border-top: 1px solid var(--border-soft);
+    color: var(--muted);
+    font-family: inherit;
+    font-size: 12.5px;
+    font-weight: 500;
+    line-height: 1;
+    cursor: pointer;
+    text-align: left;
+    border-radius: 0;
+    transition: color .12s;
+}
+.disclosure:hover { color: var(--text); }
+.disclosure-chevron {
+    width: 12px;
+    height: 12px;
+    flex-shrink: 0;
+    translate: 0 -1px;
+    transition: transform .15s ease;
+}
+.disclosure.disclosure-on { color: var(--text); }
+.disclosure.disclosure-on .disclosure-chevron { transform: rotate(90deg); }
+.disclosure-note {
+    margin-left: auto;
+    font-size: 11px;
+    color: var(--dim);
+    font-weight: 400;
+}
+.disclosure-note--ok   { color: var(--primary); font-weight: 500; }
+.disclosure-note--warn { color: var(--amber);   font-weight: 500; }
+.disclosure-body {
+    padding-top: 4px;
+}
+
+/* Segmented control (e.g. URL / Branch source picker) */
+.segmented {
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: 1fr;
+    gap: 2px;
+    padding: 3px;
+    margin-top: 6px;
+    background: var(--card-2);
+    border: 1px solid var(--border);
+    border-radius: 9px;
+}
+.segmented button {
+    padding: 7px 10px;
+    border-radius: 7px;
+    background: transparent;
+    color: var(--muted);
+    font-family: inherit;
+    font-size: 12.5px;
+    font-weight: 500;
+    cursor: pointer;
+    border: 0;
+    transition: background .12s, color .12s, box-shadow .12s;
+}
+.segmented button:hover { color: var(--text); }
+.segmented button.segmented-on {
+    background: var(--card);
+    color: var(--text);
+    box-shadow: 0 1px 2px rgba(0,0,0,.25);
+}
+:root[data-theme="light"] .segmented button.segmented-on {
+    box-shadow: 0 1px 2px rgba(16,18,21,.08);
+}
+
+/* Stacked body underneath a segmented control */
+.custom-src {
+    display: flex;
+    flex-direction: column;
+    gap: 7px;
+    margin-top: 10px;
+}
+
+/* opt-tile variant for a single inline toggle (no info icon) */
+.opt-tile--inline { min-height: 0; }
+
+/* firmware download banner */
+.dl-banner {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 13px;
+    border: 1px solid var(--amber);
+    border-radius: 9px;
+    background: var(--amber-soft);
+    color: var(--amber);
+    font-size: 12.5px;
+    margin-top: 10px;
+}
+.dl-banner-spinner {
+    width: 14px; height: 14px;
+    border-radius: 999px;
+    border: 2px solid currentColor;
+    border-right-color: transparent;
+    animation: spin .9s linear infinite;
+    flex-shrink: 0;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+.dl-banner b { color: var(--text); font-weight: 600; }
+
+/* info / hint block */
+.info-block {
+    padding: 10px 12px;
+    border: 1px solid var(--border);
+    border-radius: 9px;
+    background: var(--card-2);
+    font-size: 12px;
+    color: var(--muted);
+    line-height: 1.5;
+    margin-top: 10px;
+}
+.info-block b { color: var(--text); font-weight: 600; }
+.info-block code {
+    display: inline-block;
+    font-family: "JetBrains Mono", monospace;
+    font-size: 11px;
+    background: var(--bg-2);
+    padding: 2px 6px;
+    border-radius: 4px;
+    color: var(--text);
+    border: 1px solid var(--border);
+    margin-top: 4px;
+    word-break: break-all;
+}
+.info-block--ok   { border-color: var(--primary); background: var(--primary-soft); color: var(--primary); }
+.info-block--ok b { color: var(--primary); }
+
+/* Local Suite mount instruction card */
+.mount-card {
+    margin-top: 10px;
+    padding: 14px 16px;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--card-2);
+}
+.mount-card h4 {
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: -.005em;
+    color: var(--text);
+}
+.mount-card-hd {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 8px;
+}
+.mount-card-icon {
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+    color: var(--amber);
+}
+.mount-card-desc {
+    font-size: 12px;
+    color: var(--muted);
+    line-height: 1.5;
+    margin: 0 0 12px;
+}
+.mount-card-desc code {
+    font-family: "JetBrains Mono", monospace;
+    font-size: 11.5px;
+    background: var(--bg-2);
+    padding: 1px 6px;
+    border-radius: 4px;
+    color: var(--text);
+    border: 1px solid var(--border);
+}
+.mount-card--ok {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    border-color: var(--primary);
+    background: var(--primary-soft);
+}
+.mount-card--ok .mount-card-icon {
+    color: var(--primary);
+    margin-top: 2px;
+}
+.mount-card--ok h4 { color: var(--primary); }
+.mount-card--ok .mount-card-desc {
+    margin: 2px 0 0;
+    color: var(--primary);
+    opacity: .85;
+}
+
+.mount-steps {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+.mount-step {
+    display: grid;
+    grid-template-columns: 22px 1fr;
+    gap: 10px;
+    align-items: start;
+}
+.mount-step-num {
+    width: 22px;
+    height: 22px;
+    border-radius: 999px;
+    background: var(--card);
+    border: 1px solid var(--border);
+    color: var(--text);
+    font-size: 11px;
+    font-weight: 600;
+    display: grid;
+    place-items: center;
+    flex-shrink: 0;
+}
+.mount-step-body {
+    min-width: 0;
+}
+.mount-step-text {
+    font-size: 12.5px;
+    color: var(--text);
+    line-height: 1.45;
+    display: block;
+}
+.mount-step .code-row { margin-top: 7px; }
+
+/* Code block with inline copy button */
+.code-row {
+    display: flex;
+    align-items: stretch;
+    border: 1px solid var(--border);
+    border-radius: 7px;
+    background: var(--bg-2);
+    overflow: hidden;
+}
+.code-row code {
+    flex: 1;
+    min-width: 0;
+    padding: 8px 10px;
+    font-family: "JetBrains Mono", monospace;
+    font-size: 11.5px;
+    color: var(--text);
+    background: transparent;
+    border: 0;
+    overflow-x: auto;
+    white-space: nowrap;
+    line-height: 1.6;
+}
+.copy-btn {
+    padding: 0 11px;
+    min-width: 78px;
+    justify-content: center;
+    border: 0;
+    border-left: 1px solid var(--border);
+    background: var(--card-2);
+    color: var(--muted);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 11px;
+    font-weight: 500;
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    transition: background .2s ease, color .2s ease, border-color .2s ease;
+}
+.copy-btn:hover { background: var(--card-hover); color: var(--text); }
+.copy-btn svg { width: 12px; height: 12px; stroke: currentColor; fill: none; stroke-width: 1.8; }
+.copy-btn.copy-btn--on { color: var(--primary); background: var(--primary-soft); border-left-color: var(--primary); }
+
+/* =========================================================
+   TRANSIENT OVERLAYS
+   ========================================================= */
+
+/* Section 2: error modal (only shown for backend failures) */
+.error-modal {
+    position: fixed;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    background: rgba(0,0,0,.45);
+    z-index: 200;
+    padding: 20px;
+}
+:root[data-theme="light"] .error-modal { background: rgba(15,17,20,.28); }
+
+.error-modal-content {
+    background: var(--card);
+    border: 1px solid var(--red);
+    border-radius: 14px;
+    padding: 28px 32px 24px;
+    max-width: 520px;
+    width: 100%;
+    position: relative;
+    box-shadow: 0 0 0 2px var(--red-soft), 0 30px 80px -20px rgba(0,0,0,.45);
+}
+.error-modal-content h1 {
+    font-size: 18px;
+    font-weight: 600;
+    margin-bottom: 10px;
+    letter-spacing: -.01em;
+    color: var(--red);
+}
+.error-modal-text {
+    font-size: 14px;
+    line-height: 1.55;
+    color: var(--text-2);
+}
+.close-button {
+    position: absolute;
+    top: 14px; right: 16px;
+    cursor: pointer;
+    color: var(--muted);
+    font-size: 22px;
+    line-height: 1;
+    padding: 2px 8px;
+    border-radius: 6px;
+}
+.close-button:hover { color: var(--text); background: var(--card-2); }
+
+/* While a request is in flight, disable action buttons that would fire another
+   request — leave navigation (sidebar, flyout close, theme toggle, log clear) alive. */
+.is-waiting .cmd-btn,
+.is-waiting .cmd-body .btn,
+.is-waiting .cmd-body .opt-tile,
+.is-waiting .device-stage .btn,
+.is-waiting .topbar-actions > .btn:not(.topbar-theme),
+.is-waiting .flyout-body .btn,
+.is-waiting .flyout-body .opt-tile,
+.is-waiting .flyout-body .model,
+.is-waiting .flyout-body .vitem,
+.is-waiting .flyout-body .dial-input,
+.is-waiting .flyout-body .input,
+.is-waiting .flyout-body .select,
+.is-waiting .flyout-body .textarea,
+.is-waiting .copy-btn {
+    pointer-events: none;
+    opacity: 0.55;
+    transition: opacity .15s;
+}
+
+/* Sidebar connection-loss states */
+.reconnect-state {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 9px 12px;
+    margin-bottom: 6px;
+    border-radius: 8px;
+    font-size: 12px;
+    font-weight: 500;
+    width: 100%;
+}
+.reconnect-state--retrying {
+    background: var(--amber-soft);
+    color: var(--amber);
+    border: 1px solid var(--amber);
+    justify-content: flex-start;
+}
+.reconnect-state--lost {
+    background: transparent;
+    border: 1px solid var(--red);
+    color: var(--red);
+    justify-content: center;
+}
+.reconnect-state--lost:hover { background: var(--red-soft); }
+
+/* Waiting for response — small spinner in topbar */
+.topbar-spinner {
+    width: 16px;
+    height: 16px;
+    border-radius: 999px;
+    border: 2px solid var(--border);
+    border-top-color: var(--muted);
+    animation: spin .8s linear infinite;
+    flex-shrink: 0;
+}
+
+/* =========================================================
+   RESPONSIVE
+   ========================================================= */
+@media (max-width: 1280px) {
+    :root { --sb-col: 200px; }
+    .canvas { grid-template-columns: 1fr 300px; }
+}
+@media (max-width: 1080px) {
+    :root { --sb-col: 72px; }
+    .sb-item-text, .sb-item-tag, .sb-hd, .sb-main-head { display: none; }
+    .sidebar { padding: 12px 8px; }
+    .canvas {
+        grid-template-columns: 1fr;
+        grid-template-rows: 1fr 1fr 200px;
+    }
+    .cmd-card { grid-column: 1; grid-row: 2; }
+    .log-card { grid-column: 1; grid-row: 3; }
+    .models { grid-template-columns: repeat(3, 1fr); }
+    .topbar { padding: 0 12px; }
+    .topbar-actions .btn { padding: 6px 10px; font-size: 11px; }
 }

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -1,483 +1,856 @@
-<html>
+<!doctype html>
+<html lang="en" data-theme="dark">
     <head>
-        <title>Trezor Device Controller client</title>
+        <title>Trezor User Environment</title>
         <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="shortcut icon" href="static/favicon.ico" />
         <link rel="stylesheet" type="text/css" href="css/index.css" />
     </head>
 
     <body>
-        <div id="app" style="display: none">
+        <!--
+            Dashboard for trezor-user-env.
+            Structure maps 1:1 with docs/dashboard-overview.md (sections 1–13).
+        -->
+        <div id="app" style="display: none" :class="{ 'is-waiting': isWaitingForResponse }">
+
+            <!-- ========================================================
+                 §2 Error modal — blocking dialog for backend failures
+                 ======================================================== -->
             <div
                 v-if="notifications.showPopup"
                 id="notifications-popup"
-                class="popup"
+                class="error-modal"
                 @click="notifications.showPopup = false"
+                role="alertdialog"
+                aria-modal="true"
+                aria-labelledby="error-modal-title"
             >
-                <div
-                    :class="[
-                        'popup-content',
-                        'half-page-margins',
-                        {'red-border': notifications.isError},
-                        {'green-border': !notifications.isError}
-                    ]"
-                    @click.stop
-                >
-                    <span
-                        class="close-button"
-                        @click="notifications.showPopup = false"
-                        >&times;</span
-                    >
-                    <h1>{{ notifications.header }}</h1>
-                    <div style="font-size: xx-large">
-                        {{ notifications.text }}
+                <div class="error-modal-content" @click.stop>
+                    <span class="close-button" @click="notifications.showPopup = false" aria-label="Close">×</span>
+                    <h1 id="error-modal-title">{{ notifications.header }}</h1>
+                    <div class="error-modal-text">{{ notifications.text }}</div>
+                </div>
+            </div>
+
+
+            <!-- ========================================================
+                 SHELL
+                 ======================================================== -->
+            <div class="shell">
+
+                <!-- Top bar — spans full width -->
+                <div class="topbar">
+                    <div class="topbar-brand">
+                        <svg class="topbar-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 66">
+                            <path d="M158.104 20.017h26.741v7.037L170.302 46.76h14.543v8.288h-26.741V48.01l14.544-19.705h-14.544zm90.233 22.05c3.284-1.25 6.725-4.535 6.725-10.321 0-7.037-4.848-11.573-12.042-11.573H226.6v34.874h9.07V43.318h3.44l6.412 11.729H256zm-6.412-6.88h-6.255v-7.038h6.255c2.346 0 3.91 1.408 3.91 3.44 0 2.19-1.564 3.597-3.91 3.597M204.55 19.547c-10.634 0-18.14 7.663-18.14 17.984s7.662 17.984 18.14 17.984c10.477 0 18.297-7.663 18.297-17.984s-7.663-17.984-18.297-17.984m0 27.836c-5.317 0-8.914-4.066-8.914-9.852 0-5.943 3.597-9.852 8.914-9.852s9.07 4.066 9.07 9.852-3.753 9.852-9.07 9.852m-76.16-27.366h25.334v8.132H137.46v5.16h15.795v7.976H137.46v5.63h16.264v8.132H128.39zm-89.92-4.848C38.47 6.881 31.276 0 22.518 0S6.57 6.88 6.57 15.17v4.847H0v34.874l22.52 10.477 22.518-10.477V20.173H38.47zm-23.77 0c0-3.91 3.44-7.037 7.818-7.037s7.82 3.128 7.82 7.037v4.848H14.7zm21.267 34.092L22.52 55.516 9.07 49.261V28.305h26.898zm88.2-17.515c0-7.037-4.847-11.573-12.04-11.573H95.706v34.874h9.07V43.318h3.44l6.412 11.729h10.478l-7.663-12.98c3.284-1.25 6.725-4.535 6.725-10.321m-13.136 3.44h-6.255V28.15h6.255c2.346 0 3.91 1.408 3.91 3.44 0 2.19-1.564 3.597-3.91 3.597m-47.697-15.17h28.306v8.288h-9.696v26.742h-9.07V28.305h-9.54z"/>
+                        </svg>
+                        <span class="topbar-brand-sep"></span>
+                        <span class="topbar-brand-name">Emulator</span>
+                    </div>
+                    <div class="topbar-spacer"></div>
+                    <span v-if="isWaitingForResponse" class="topbar-spinner" title="Waiting for response…"></span>
+                    <div class="topbar-actions">
+                        <button class="btn btn--sm" @click="openFlyout('flyEmu')">
+                            <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+                            Emulator setup
+                        </button>
+                        <button v-if="emulators.vncActive" class="btn btn--sm btn--danger" @click="emulatorStop()">
+                            <svg viewBox="0 0 24 24"><rect x="6" y="6" width="12" height="12" rx="1"/></svg>
+                            Stop
+                        </button>
+                        <button v-else class="btn btn--sm btn--primary" @click="emulatorStart(selectedEmulatorModel)">
+                            <svg viewBox="0 0 24 24"><polygon points="5 3 19 12 5 21"/></svg>
+                            Start emulator
+                        </button>
+                        <button class="btn btn--sm btn--icon btn--ghost topbar-theme" @click="toggleTheme()" :aria-label="theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'" :title="theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'">
+                            <svg v-if="theme === 'dark'" viewBox="0 0 24 24"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="4"/><line x1="12" y1="20" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="6.34" y2="6.34"/><line x1="17.66" y1="17.66" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="4" y2="12"/><line x1="20" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="6.34" y2="17.66"/><line x1="17.66" y1="6.34" x2="19.78" y2="4.22"/></svg>
+                            <svg v-else viewBox="0 0 24 24"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+                        </button>
                     </div>
                 </div>
-            </div>
 
-            <div class="waiting-for-response" v-if="isWaitingForResponse">
-                WAITING FOR RESPONSE (ignoring all inputs)
-            </div>
+                <!-- ========== SIDEBAR ========== -->
+                <aside class="sidebar">
 
-            <div v-if="!ws" id="ws-status">
-                <div>
-                    Websocket server not connected.
-                    <button @click="setupWebSocket()">Connect</button>
+
+                    <!-- §1 Connection state — only shown when WS is lost -->
+                    <div v-if="!ws && wsReconnecting" class="reconnect-state reconnect-state--retrying">
+                        <span class="topbar-spinner" style="width:12px;height:12px;border-width:1.5px;border-color:var(--amber);border-top-color:transparent"></span>
+                        <span>Reconnecting…</span>
+                    </div>
+                    <button
+                        v-else-if="!ws"
+                        class="btn btn--full reconnect-state reconnect-state--lost"
+                        @click="wsRetries = 0; setupWebSocket()"
+                    >Reconnect</button>
+
+                    <!-- Sidebar main header — mirrors .card-head h3 on the right -->
+                    <div class="sb-main-head">
+                        <h3>Control</h3>
+                    </div>
+
+                    <!-- Services -->
+                    <div class="sb-hd">
+                        <span>Services</span>
+                        <span class="sb-legend-tip">
+                            <span class="sb-legend-title">Dots show live service state</span>
+                            <span class="sb-legend-row"><span class="sb-legend-dot sb-legend-dot--ok"></span>running</span>
+                            <span class="sb-legend-row"><span class="sb-legend-dot sb-legend-dot--err"></span>stopped</span>
+                            <span class="sb-legend-row"><span class="sb-legend-dot sb-legend-dot--unk"></span>unknown</span>
+                        </span>
+                    </div>
+
+                    <!-- §4 Emulator -->
+                    <button :class="['sb-item', { 'sb-item--on': openFly === 'flyEmu' }]" @click="openFlyout('flyEmu')">
+                        <svg class="sb-item-icon" viewBox="0 0 24 24"><rect x="5" y="2" width="14" height="20" rx="3"/><line x1="10" y1="18" x2="14" y2="18"/></svg>
+                        <span class="sb-item-text">
+                            <span class="sb-item-label">Emulator</span>
+                            <span v-if="emulators.runningVersion" class="sb-item-version">{{ emulators.runningVersion }}</span>
+                        </span>
+                        <span
+                            :class="[
+                                'sb-item-dot',
+                                { 'sb-item-dot--ok':  emulators.statusColor === 'green' },
+                                { 'sb-item-dot--err': emulators.statusColor === 'red' },
+                                { 'sb-item-dot--unk': emulators.statusColor === 'black' }
+                            ]"
+                        ></span>
+                    </button>
+
+                    <!-- §3 Bridge -->
+                    <button :class="['sb-item', { 'sb-item--on': openFly === 'flyBrg' }]" @click="openFlyout('flyBrg')">
+                        <svg class="sb-item-icon" viewBox="0 0 24 24"><path d="M4 16 C4 12 8 9 12 9 C16 9 20 12 20 16"/><line x1="2" y1="16" x2="22" y2="16"/><line x1="12" y1="13" x2="12" y2="20"/></svg>
+                        <span class="sb-item-text">
+                            <span class="sb-item-label">Bridge</span>
+                            <span v-if="bridges.runningVersion" class="sb-item-version">{{ bridges.runningVersion }}</span>
+                        </span>
+                        <span
+                            :class="[
+                                'sb-item-dot',
+                                { 'sb-item-dot--ok':  bridges.statusColor === 'green' },
+                                { 'sb-item-dot--err': bridges.statusColor === 'red' },
+                                { 'sb-item-dot--unk': bridges.statusColor === 'black' }
+                            ]"
+                        ></span>
+                    </button>
+
+                    <!-- §5 Tropic Square — conditional on Safe 7 (T3W1) -->
+                    <button
+                        v-if="showTropicSection"
+                        :class="['sb-item', { 'sb-item--on': openFly === 'flyTropic' }]"
+                        @click="openFlyout('flyTropic')"
+                    >
+                        <svg class="sb-item-icon" viewBox="0 0 24 24"><rect x="5" y="5" width="14" height="14" rx="1"/><circle cx="12" cy="12" r="3"/></svg>
+                        <span class="sb-item-text">
+                            <span class="sb-item-label">Tropic Square</span>
+                            <span v-if="tropic.runningVersion" class="sb-item-version">{{ tropic.runningVersion }}</span>
+                        </span>
+                        <span
+                            :class="[
+                                'sb-item-dot',
+                                { 'sb-item-dot--ok':  tropic.statusColor === 'green' },
+                                { 'sb-item-dot--err': tropic.statusColor === 'red' },
+                                { 'sb-item-dot--unk': tropic.statusColor === 'black' }
+                            ]"
+                        ></span>
+                    </button>
+                    <button
+                        v-else
+                        class="sb-item sb-item--disabled"
+                        aria-disabled="true"
+                        @click.prevent
+                        data-tooltip="Only available when Trezor Safe 7 (T3W1) is selected or running."
+                    >
+                        <svg class="sb-item-icon" viewBox="0 0 24 24"><rect x="5" y="5" width="14" height="14" rx="1"/><circle cx="12" cy="12" r="3"/></svg>
+                        <span class="sb-item-label">Tropic Square</span>
+                    </button>
+
+                    <!-- §6 Regtest -->
+                    <button :class="['sb-item', { 'sb-item--on': openFly === 'flyReg' }]" @click="openFlyout('flyReg')">
+                        <svg class="sb-item-icon" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M9 8h5a2 2 0 0 1 0 4H9zm0 4h6a2 2 0 0 1 0 4H9z"/></svg>
+                        <span class="sb-item-text">
+                            <span class="sb-item-label">Regtest</span>
+                        </span>
+                        <span
+                            :class="[
+                                'sb-item-dot',
+                                { 'sb-item-dot--ok':  regtest.statusColor === 'green' },
+                                { 'sb-item-dot--err': regtest.statusColor === 'red' },
+                                { 'sb-item-dot--unk': regtest.statusColor === 'black' }
+                            ]"
+                        ></span>
+                    </button>
+
+                    <!-- §7 Tools -->
+                    <div class="sb-hd">Tools</div>
+
+                    <button :class="['sb-item', { 'sb-item--on': openFly === 'flyRaw' }]" @click="openFlyout('flyRaw')">
+                        <svg class="sb-item-icon" viewBox="0 0 24 24"><polyline points="8 6 2 12 8 18"/><polyline points="16 6 22 12 16 18"/></svg>
+                        <span class="sb-item-label">Server</span>
+                    </button>
+
+
+                </aside>
+
+                <!-- ========== MAIN ========== -->
+                <!-- Canvas -->
+                    <div class="canvas">
+
+                        <!-- §8 Device display (VNC live view) -->
+                        <section class="card device-card">
+                            <div class="card-head">
+                                <h3>
+                                    <template v-if="emulators.runningModel">
+                                        {{ emulators.versions[emulators.runningModel]?.header }}
+                                        <span class="card-head-tag">{{ emulators.runningModel }}</span>
+                                    </template>
+                                    <template v-else>Device</template>
+                                </h3>
+                                <div class="card-head-right">
+                                    <button
+                                        class="btn btn--sm btn--ghost"
+                                        :disabled="!emulators.vncActive"
+                                        @click="reloadVnc()"
+                                        data-tooltip="Reload live view"
+                                        data-tooltip-pos="right"
+                                    >
+                                        <svg viewBox="0 0 24 24"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>
+                                        Reload
+                                    </button>
+                                    <button
+                                        class="btn btn--sm btn--ghost"
+                                        :disabled="!emulators.vncActive"
+                                        @click="openVncPopup()"
+                                        data-tooltip="Open the emulator in a separate, resizable window"
+                                        data-tooltip-pos="right"
+                                        aria-label="Open the emulator in a separate window"
+                                    >
+                                        <svg viewBox="0 0 24 24"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+                                        Pop out
+                                    </button>
+                                </div>
+                            </div>
+                            <div class="device-stage">
+                                <iframe
+                                    v-if="emulators.vncActive"
+                                    id="vnc-iframe"
+                                    :src="vncUrl"
+                                    class="vnc-iframe"
+                                ></iframe>
+                                <div v-else class="device-empty">
+                                    <div class="device-empty-icon">
+                                        <svg viewBox="0 0 24 24">
+                                            <rect x="6" y="2" width="12" height="20" rx="3"/>
+                                            <line x1="10" y1="18" x2="14" y2="18"/>
+                                        </svg>
+                                    </div>
+                                    <h4>No emulator running</h4>
+
+                                    <ol v-if="bridges.statusColor === 'red'" class="device-empty-steps">
+                                        <li>
+                                            <span class="device-empty-num">1</span>
+                                            <div>
+                                                <b>Start the Bridge service</b>
+                                                <span>Required for host apps and the emulator to talk to one another.</span>
+                                                <button class="btn btn--sm" @click="openFlyout('flyBrg')">Open Bridge</button>
+                                            </div>
+                                        </li>
+                                        <li>
+                                            <span class="device-empty-num">2</span>
+                                            <div>
+                                                <b>Pick a model and start the emulator</b>
+                                                <span>The live device view will appear here.</span>
+                                                <button class="btn btn--sm btn--primary" @click="openFlyout('flyEmu')">Open Emulator setup</button>
+                                            </div>
+                                        </li>
+                                    </ol>
+
+                                    <p v-else>Pick a device model and press <b>Start</b>. The live view will appear here.</p>
+                                    <button v-if="bridges.statusColor === 'green'" class="btn btn--primary" @click="openFlyout('flyEmu')">
+                                        Open Emulator setup
+                                    </button>
+                                </div>
+                            </div>
+                        </section>
+
+                        <!-- §9 Emulator commands -->
+                        <section class="card cmd-card">
+                            <div class="card-head">
+                                <h3>Commands</h3>
+                                <div class="card-head-right">
+                                    <span class="info-tip" data-tooltip="auto-confirmed via debug link">
+                                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+                                    </span>
+                                </div>
+                            </div>
+                            <div class="cmd-body">
+
+                                <!-- §9.1 Simulate — button-input models only (T1B1, T3B1) -->
+                                <div v-if="emulatorHasButtons" class="cmd-sec">
+                                    <h5>Simulate</h5>
+                                    <div class="row2">
+                                        <button class="cmd-btn" @click="emulatorPressYes()" data-tooltip="Simulates pressing the physical confirm button on the device">
+                                            <span>Yes / confirm</span>
+                                        </button>
+                                        <button class="cmd-btn" @click="emulatorPressNo()" data-tooltip="Simulates pressing the physical cancel button on the device" data-tooltip-pos="right">
+                                            <span>No / cancel</span>
+                                        </button>
+                                    </div>
+                                </div>
+
+                                <!-- §9.2 Setup — seed -->
+                                <div class="cmd-sec">
+                                    <h5>Setup — seed</h5>
+                                    <label class="opt-tile" style="width: 100%" data-tooltip="Applies to the next Load seed action — does not affect an already-loaded seed.">
+                                        <input type="checkbox" v-model="enablePassphrase" />
+                                        <span class="opt-tile-name">Passphrase protection</span>
+                                    </label>
+                                    <div class="row2" style="margin-top: 7px">
+                                        <button class="cmd-btn cmd-btn--seed" @click="emulatorSetup('all')" data-tooltip="Loads the &quot;all&quot; test seed — a 12-word mnemonic covering all supported coin types">
+                                            <span class="cmd-btn-seed-label">Load "all"</span>
+                                            <span class="cmd-btn-tag">12 words</span>
+                                        </button>
+                                        <button class="cmd-btn cmd-btn--seed" @click="emulatorSetup('academic')" data-tooltip="Loads the &quot;academic&quot; test seed — a 20-word mnemonic used in test suites">
+                                            <span class="cmd-btn-seed-label">Load "academic"</span>
+                                            <span class="cmd-btn-tag">20 words</span>
+                                        </button>
+                                    </div>
+                                    <div style="display: flex; gap: 6px; margin-top: 6px">
+                                        <input
+                                            class="input"
+                                            type="text"
+                                            placeholder="Custom mnemonic…"
+                                            v-model="emulatorCommands.seed"
+                                            style="flex: 1; min-width: 0"
+                                        />
+                                        <button class="btn btn--sm" @click="emulatorSetup()" data-tooltip="Load the mnemonic typed in the field" data-tooltip-pos="right">Load</button>
+                                    </div>
+                                </div>
+
+                                <!-- §9.2 Setup — lifecycle -->
+                                <div class="cmd-sec">
+                                    <h5>Setup — lifecycle</h5>
+                                    <button class="cmd-btn cmd-btn--danger" style="width:100%;margin-bottom:6px" @click="emulatorWipe()" data-tooltip="Wipes the emulator — removes all data and returns to factory state">Wipe</button>
+                                    <div class="row2">
+                                        <button class="cmd-btn" @click="emulatorResetDevice()" data-tooltip="Initializes a new wallet on the emulator (standard single-seed setup)">Reset</button>
+                                        <button class="cmd-btn" @click="emulatorResetDeviceShamir()" data-tooltip="Initializes a new wallet using Shamir Secret Sharing backup" data-tooltip-pos="right">Reset w/ Shamir</button>
+                                    </div>
+                                </div>
+
+                                <!-- §9.3 Verify & debug -->
+                                <div class="cmd-sec">
+                                    <h5>Verify &amp; debug</h5>
+
+                                    <button class="cmd-btn" style="margin-bottom: 7px" @click="readAndConfirmMnemonic()" data-tooltip="Reads the current seed phrase from the emulator and simulates confirming each word on the device">
+                                        <span>Read &amp; confirm mnemonic</span>
+                                    </button>
+
+                                    <div class="shamir-group">
+                                        <div class="shamir-dials">
+                                            <div class="dial">
+                                                <button type="button" class="dial-step" @click="emulatorCommands.shamirShares = Math.max(1, (emulatorCommands.shamirShares || 1) - 1)" aria-label="Decrease shares">−</button>
+                                                <div class="dial-stack">
+                                                    <span class="dial-label">shares</span>
+                                                    <input
+                                                        class="dial-input"
+                                                        type="number" min="1" max="20"
+                                                        v-model.number="emulatorCommands.shamirShares"
+                                                    />
+                                                </div>
+                                                <button type="button" class="dial-step" @click="emulatorCommands.shamirShares = Math.min(20, (emulatorCommands.shamirShares || 0) + 1)" aria-label="Increase shares">+</button>
+                                            </div>
+                                            <div class="dial">
+                                                <button type="button" class="dial-step" @click="emulatorCommands.shamirThreshold = Math.max(1, (emulatorCommands.shamirThreshold || 1) - 1)" aria-label="Decrease threshold">−</button>
+                                                <div class="dial-stack">
+                                                    <span class="dial-label">threshold</span>
+                                                    <input
+                                                        class="dial-input"
+                                                        type="number" min="1" max="20"
+                                                        v-model.number="emulatorCommands.shamirThreshold"
+                                                    />
+                                                </div>
+                                                <button type="button" class="dial-step" @click="emulatorCommands.shamirThreshold = Math.min(20, (emulatorCommands.shamirThreshold || 0) + 1)" aria-label="Increase threshold">+</button>
+                                            </div>
+                                        </div>
+                                        <button class="cmd-btn" @click="readAndConfirmMnemonicShamir()" data-tooltip="Reads and confirms all Shamir shares using the configured shares and threshold values">
+                                            <span>Read &amp; confirm Shamir</span>
+                                        </button>
+                                    </div>
+
+                                    <div class="row2">
+                                        <button class="cmd-btn" @click="emulatorGetFeatures()" data-tooltip="Fetches and logs the device feature flags and capabilities">
+                                            <span>Get features</span>
+                                        </button>
+                                        <button class="cmd-btn" @click="emulatorSetBackupState()" data-tooltip="Marks the backup as done — useful for skipping the backup prompt in test flows" data-tooltip-pos="right">
+                                            <span>Set backup state</span>
+                                        </button>
+                                    </div>
+
+                                    <button class="cmd-btn cmd-btn--warn" style="margin-top: 7px" @click="emulatorAllowUnsafe()" data-tooltip="Allows the emulator to derive keys from unusual paths — use only for specific test flows.">
+                                        <span>Safety checks off</span>
+                                    </button>
+                                </div>
+
+                                <!-- §9.4 N4W1 NFC — T3W1 only -->
+                                <div v-if="showTropicSection" class="cmd-sec">
+                                    <h5>N4W1 NFC tag</h5>
+                                    <div style="display:flex;gap:6px;align-items:center">
+                                        <span style="font-size:11.5px;color:var(--muted);white-space:nowrap">Tag ID</span>
+                                        <input
+                                            class="input"
+                                            type="number"
+                                            min="1"
+                                            max="100"
+                                            v-model.number="emulatorCommands.n4w1TagId"
+                                            style="width:58px;flex-shrink:0;text-align:center;padding:6px 8px"
+                                        />
+                                        <button class="cmd-btn" style="flex:1" @click="n4w1Tap()" data-tooltip="Simulate an NFC tag tap on the emulator">Tap</button>
+                                        <button class="cmd-btn" style="flex:1" @click="n4w1Clear()" data-tooltip="Clear the NFC tag data stored for this tag ID" data-tooltip-pos="right">Clear</button>
+                                    </div>
+                                </div>
+
+                            </div>
+                        </section>
+
+                        <!-- §10 Event log -->
+                        <section class="card log-card">
+                            <div class="card-head">
+                                <h3>
+                                    Event log
+                                    <span class="card-head-tag">{{ logs.length }} events</span>
+                                </h3>
+                                <div class="card-head-right log-filters">
+                                    <button
+                                        v-for="f in logFilterOptions"
+                                        :key="f.k"
+                                        :class="['log-filter', { 'log-filter--on': logFilter === f.k }]"
+                                        @click="logFilter = f.k"
+                                    >{{ f.label }}</button>
+                                    <button class="log-tools-clear" @click="logs = []; unseenLogs = 0">Clear</button>
+                                </div>
+                            </div>
+                            <button
+                                v-if="unseenLogs > 0"
+                                class="log-unseen-chip"
+                                @click="clearUnseen()"
+                            >↑ {{ unseenLogs }} new event<span v-if="unseenLogs !== 1">s</span></button>
+                            <div class="log-entries" ref="logContainer" @scroll="onLogScroll">
+                                <p
+                                    v-for="log in filteredLogs"
+                                    :key="log.id"
+                                    :style="{ color: log.color }"
+                                >{{ log.text }}</p>
+                                <div v-if="!filteredLogs.length" class="log-empty">
+                                    <span v-if="logFilter !== 'all' && logs.length">No {{ logFilter }} events yet.</span>
+                                    <span v-else>No events yet. Start the bridge or emulator to see outbound requests and backend responses.</span>
+                                </div>
+                            </div>
+                        </section>
+
+                    </div>
                 </div>
-            </div>
-    <div class="sections-container">
 
-            <section>
-        <h3>Bridge</h3>
-        <div>
-            <i>Start Bridge with emulator support.</i><br />
-            <select v-model="bridges.selected">
-                <option
-                            v-for="option in bridges.versions"
+            <!-- ========================================================
+                 FLYOUTS (module configuration panels)
+                 ======================================================== -->
+            <div
+                :class="['flyout-backdrop', { 'flyout-backdrop--on': openFly }]"
+                @click="closeFlyouts()"
+            ></div>
+
+            <!-- §4 Emulator -->
+            <aside :class="['flyout', { 'flyout--open': openFly === 'flyEmu', 'flyout--locked': !!emulatorDownloadMessage }]">
+                <div class="flyout-head">
+                    <div class="flyout-head-title">
+                        <h2>Emulator</h2>
+                        <div class="flyout-head-desc">
+                            Pick a device model and firmware version, toggle launch options, then start.
+                        </div>
+                    </div>
+                    <button class="flyout-close" @click="closeFlyouts()" aria-label="Close panel" title="Close panel">
+                        <svg viewBox="0 0 24 24"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+                    </button>
+                </div>
+                <div class="flyout-body">
+
+                    <label class="field-label">Device model</label>
+                    <div class="models">
+                        <button
+                            v-for="(details, model) in emulators.versions"
+                            :key="model"
+                            type="button"
+                            :class="[
+                                'model',
+                                { 'model--selected': selectedEmulatorModel === model },
+                                { 'model--running':  emulators.runningModel  === model }
+                            ]"
+                            @click="selectedEmulatorModel = model"
+                        >
+                            <div class="model-id">{{ model }}</div>
+                            <div class="model-name">{{ details.header }}</div>
+                            <div class="model-type">{{ details.inputType }}</div>
+                        </button>
+                    </div>
+
+                    <label class="field-label">Firmware version</label>
+                    <select
+                        class="select"
+                        v-model="emulators.versions[selectedEmulatorModel].selected"
+                    >
+                        <option
+                            v-for="option in emulators.versions[selectedEmulatorModel].versions"
                             :key="option"
                             :value="option"
-                        >
-                            {{ option }}
-                        </option>
+                        >{{ option }}</option>
                     </select>
-                    <button class="positive" @click="bridgeStart()">Start</button>
-                    <button class="negative" @click="bridgeStop()">Stop</button>
-                    <input
-                        id="bridgeUseLogfile"
-                        type="checkbox"
-                        v-model="bridges.outputToLogfile"
-                    />
-                    <label
-                        class="underlined"
-                        title="Save bridge logs into logfile. Otherwise, logs are shown in console."
-                        for="bridgeUseLogfile"
-                        >Logs into logfile</label
-                    ><br />
-                </div>
-                <div>
-                    <div :style="{ color: bridges.statusColor }">
-                        <b>Status: <span>{{ bridges.status }}</span></b>
+
+                    <label class="field-label">
+                        Launch options
+                        <span class="field-label-note">(applies to the next start)</span>
+                    </label>
+                    <div class="opt-grid">
+                        <label class="opt-tile" data-tooltip="Enable UI animations on the emulator display">
+                            <input id="animations" type="checkbox" v-model="emulators.animations" />
+                            <span class="opt-tile-name">Animations</span>
+                        </label>
+                        <label class="opt-tile" data-tooltip="Wipe the device state each time the emulator starts">
+                            <input id="wipeDevice" type="checkbox" v-model="emulators.wipeDevice" />
+                            <span class="opt-tile-name">Wipe on start</span>
+                        </label>
+                        <label class="opt-tile" data-tooltip="Redirect emulator output to a log file instead of stdout">
+                            <input id="emulatorUseLogfile" type="checkbox" v-model="emulators.outputToLogfile" />
+                            <span class="opt-tile-name">Log to file</span>
+                        </label>
+                        <label class="opt-tile" data-tooltip="Removes the red debug marker from screenshots and saves captures to logs/screens">
+                            <input id="emulatorSaveScreenshots" type="checkbox" v-model="emulators.screenshotMode" />
+                            <span class="opt-tile-name">Screenshot mode</span>
+                        </label>
                     </div>
-                    <div class="explain-note">
-                        You may also check bridge status page on
-                        <a href="http://0.0.0.0:21328/status/" target="_blank">
-                            http://0.0.0.0:21328/status/
-                        </a>
-                        when the bridge is running
 
-                        <div v-if="bridges.hasSuiteLocal" :style="{ color: 'green' }">
-                            You have mounted local Suite - local node bridge is available.
-                        </div>
-                        <div v-else>
-                            Local Suite is not mounted - if needed, run `ln -s [local-suite-path] trezor-suite` in root dir and restart server.
-                        </div>
-                    </div>
-                </div>
-            </section>
-
-            <section>
-                <h3>Tropic Square Model Server</h3>
-                <div>
-                    <i>Control Tropic Square model server (required for T3W1 emulator).</i><br />
-                    <button class="positive" @click="tropicStart()">Start</button>
-                    <button class="negative" @click="tropicStop()">Stop</button>
-                    <input
-                        id="tropicUseLogfile"
-                        type="checkbox"
-                        v-model="tropic.outputToLogfile"
-                    />
-                    <label
-                        class="underlined"
-                        title="Save tropic model logs into logfile. Otherwise, logs are shown in console."
-                        for="tropicUseLogfile"
-                        >Logs into logfile</label
-                    ><br />
-                </div>
-                <div>
-                    <div :style="{ color: tropic.statusColor }">
-                        <b>Status: <span>{{ tropic.status }}</span></b>
-                    </div>
-                    <div class="explain-note">
-                        The Tropic Square model server is automatically started when launching
-                        a T3W1 emulator, but can also be controlled manually here.
-                    </div>
-                </div>
-            </section>
-
-            <section>
-                <h3>Emulator</h3>
-                <div class="explain-note">
-                    Use left and right arrow keys to emulate the Trezor
-                    One/Safe3 buttons. Mouse clicks for other models.
-                </div>
-
-                <br />
-
-                <div :style="{ color: emulators.statusColor }">
-                    <b>Status: <span>{{ emulators.status }}</span></b>
-                </div>
-
-                <div
-                    v-for="(details, model) in emulators.versions"
-                    :key="model"
-                >
-                    <h4>{{details.header}} ({{ model }})</h4>
-                    <select v-model="details.selected">
-                        <option
-                            v-for="option in details.versions"
-                            :key="option"
-                            :value="option"
-                        >
-                            {{ option }}
-                        </option>
-                    </select>
-                    <button class="positive" @click="emulatorStart(model);">Start</button>
-                </div>
-
-                <div>
-                    <input
-                        id="animations"
-                        type="checkbox"
-                        v-model="emulators.animations"
-                    />
-                    <label
-                        class="underlined"
-                        title="Animations will be turned on."
-                        for="animations"
-                        >Show animations</label
+                    <button
+                        type="button"
+                        :class="['disclosure', { 'disclosure-on': customFirmwareOpen }]"
+                        @click="customFirmwareOpen = !customFirmwareOpen"
                     >
-                    <br />
-                    <input
-                        id="wipeDevice"
-                        type="checkbox"
-                        v-model="emulators.wipeDevice"
-                    />
-                    <label
-                        class="underlined"
-                        title="Device will be started without seed or any other settings."
-                        for="wipeDevice"
-                        >Start with wiped/empty device</label
-                    >
-                    <br />
-                    <input
-                        id="emulatorUseLogfile"
-                        type="checkbox"
-                        v-model="emulators.outputToLogfile"
-                    />
-                    <label
-                        class="underlined"
-                        title="Save emulator logs into logfile. Otherwise, logs are shown in console."
-                        for="emulatorUseLogfile"
-                        >Logs into logfile</label
-                    >
-                    <br />
-                    <input
-                        id="emulatorSaveScreenshots"
-                        type="checkbox"
-                        v-model="emulators.screenshotMode"
-                    />
-                    <label
-                        class="underlined"
-                        title="
-                No square in top right corner.
-                Screenshots are saved under `logs/screens`.
-                NOTE:
-                - does not work for T1
-                - the first screen does contain the square, no way to change it."
-                        for="emulatorSaveScreenshots"
-                        >Screenshot mode</label
-                    >
-                    <br />
-                </div>
-
-                <hr />
-
-                <div>
-                    <input
-                        type="text"
-                        placeholder="Full emulator URL. Do not forget to specify correct model"
-                        style="width: 40%"
-                        v-model="emulatorUrl.url"
-                    />
-                    <select v-model="emulatorUrl.model">
-                        <option
-                            v-for="(details, model) in emulators.versions"
-                            :value="model"
-                            :key="model"
-                        >
-                            {{ details.header }}
-                        </option>
-                    </select>
-                    <button class="positive" @click="emulatorStartFromUrl();">
-                        Start from URL
+                        <svg class="disclosure-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 6 15 12 9 18"/></svg>
+                        <span>Custom firmware</span>
+                        <span class="disclosure-note">URL or branch build (overrides model &amp; firmware above)</span>
                     </button>
-                </div>
 
-                <div>
-                    <input
-                        type="text"
-                        placeholder="Firmware branch. Do not forget to specify correct model"
-                        style="width: 30%"
-                        v-model="emulatorBranch.branch"
-                    />
-                    <select v-model="emulatorBranch.model">
-                        <option
-                            v-for="(details, model) in emulators.versions"
-                            :value="model"
-                            :key="model"
-                        >
-                            {{ details.header }}
-                        </option>
-                    </select>
-                        <input
-                        id="emulatorBtcOnly"
-                        type="checkbox"
-                        v-model="emulatorBranch.btcOnly"
-                    />
-                    <label
-                        class="underlined"
-                        title="Use BTC-only version of the emulator."
-                        for="emulatorBtcOnly"
-                        >BTC-only</label
-                    >
-                    <button class="positive" @click="emulatorStartFromBranch();">
-                        Start from branch
-                    </button>
-                </div>
+                    <div v-if="customFirmwareOpen" class="disclosure-body">
+                        <div class="segmented" role="tablist">
+                            <button
+                                type="button"
+                                role="tab"
+                                :class="{ 'segmented-on': customFirmwareSource === 'url' }"
+                                @click="customFirmwareSource = 'url'"
+                            >From URL</button>
+                            <button
+                                type="button"
+                                role="tab"
+                                :class="{ 'segmented-on': customFirmwareSource === 'branch' }"
+                                @click="customFirmwareSource = 'branch'"
+                            >From branch</button>
+                        </div>
 
-                <div class="user-info" v-if="emulatorDownloadMessage">
-                    {{ emulatorDownloadMessage }}
-                </div>
+                        <div v-if="customFirmwareSource === 'url'" class="custom-src">
+                            <input class="input" type="text" placeholder="https://data.trezor.io/firmware/…" v-model="emulatorUrl.url" />
+                            <select class="select" v-model="emulatorUrl.model">
+                                <option value="" disabled>Confirm / correct the model…</option>
+                                <option v-for="(details, model) in emulators.versions" :key="model" :value="model">
+                                    {{ details.header }} ({{ model }})
+                                </option>
+                            </select>
+                            <button class="btn btn--full" @click="emulatorStartFromUrl()">
+                                Launch from URL
+                            </button>
+                        </div>
 
-                <hr />
-
-                <button class="negative" @click="emulatorStop();">Stop</button>
-            </section>
-
-            <section v-if="emulators.vncActive" class="vnc-viewer">
-                <div class="vnc-toolbar">
-                    <h3>Device Display (VNC)</h3>
-                    <div>
-                        <button @click="reloadVnc();">Reload</button>
-                        <button @click="openVncPopup();">Open in popup</button>
-                    </div>
-                </div>
-                <iframe
-                    id="vnc-iframe"
-                    src="http://localhost:6080/vnc_embed.html"
-                    class="vnc-iframe"
-                ></iframe>
-            </section>
-
-            <section>
-                <h3>Emulator commands</h3>
-                <div class="explain-note">
-                    These commands are auto-confirmed using the emulator's debug
-                    link.
-                </div>
-                <br />
-                <div>
-                    <div class="wipe-yes-no">
-                        <button @click="emulatorWipe();">Wipe</button>
-                        <div>
-                            <button class="positive" @click="emulatorPressYes();">Press yes</button>
-                            <button class="negative" @click="emulatorPressNo();">Press no</button>
+                        <div v-else class="custom-src">
+                            <input class="input" type="text" placeholder="e.g. feature/new-ui" v-model="emulatorBranch.branch" />
+                            <select class="select" v-model="emulatorBranch.model">
+                                <option value="" disabled>Model…</option>
+                                <option v-for="(details, model) in emulators.versions" :key="model" :value="model">
+                                    {{ details.header }} ({{ model }})
+                                </option>
+                            </select>
+                            <label class="opt-tile opt-tile--inline">
+                                <input id="emulatorBtcOnly" type="checkbox" v-model="emulatorBranch.btcOnly" />
+                                <span class="opt-tile-name">BTC-only build variant</span>
+                            </label>
+                            <button class="btn btn--full" @click="emulatorStartFromBranch()">
+                                Launch from branch
+                            </button>
                         </div>
                     </div>
-                    <input
-                        id="enablePassphrase"
-                        type="checkbox"
-                        v-model="enablePassphrase"
-                    />
-                    <label
-                        class="underlined"
-                        title="Passphrase protection will be enabled with loading seed."
-                        for="enablePassphrase"
-                        >Enable passphrase protection with Load</label
+
+                    <!-- Firmware download indicator -->
+                    <div v-if="emulatorDownloadMessage" class="dl-banner">
+                        <span class="dl-banner-spinner"></span>
+                        <div><b>Downloading firmware…</b> {{ emulatorDownloadMessage }}</div>
+                    </div>
+
+                    <div class="flyout-actions">
+                        <button class="btn btn--primary" @click="emulatorStart(selectedEmulatorModel)">
+                            Start emulator
+                        </button>
+                        <button class="btn btn--danger" @click="emulatorStop()">
+                            Stop
+                        </button>
+                    </div>
+                </div>
+            </aside>
+
+            <!-- §3 Bridge -->
+            <aside :class="['flyout', { 'flyout--open': openFly === 'flyBrg' }]">
+                <div class="flyout-head">
+                    <div class="flyout-head-title">
+                        <h2>Bridge <span class="mono">· trezord</span></h2>
+                        <div class="flyout-head-desc">
+                            The <code>trezord</code> service that lets host applications talk to the device / emulator.
+                            Pick a version while stopped, then start.
+                        </div>
+                    </div>
+                    <button class="flyout-close" @click="closeFlyouts()" aria-label="Close panel" title="Close panel">
+                        <svg viewBox="0 0 24 24"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+                    </button>
+                </div>
+                <div class="flyout-body">
+
+                    <label class="field-label">Version</label>
+                    <div v-if="bridges.statusColor === 'green'" class="field-hint" style="margin-top: 0; margin-bottom: 8px">
+                        Stop the bridge to change version.
+                    </div>
+                    <div class="vlist">
+                        <button
+                            v-for="v in modernBridgeVersions"
+                            :key="v"
+                            type="button"
+                            :class="['vitem', { 'vitem--selected': bridges.selected === v }]"
+                            :disabled="bridges.statusColor === 'green'"
+                            @click="bridges.selected = v"
+                        >
+                            <span class="vitem-name">{{ v }}</span>
+                            <span v-if="bridges.statusColor === 'green' && bridges.selected === v" class="vitem-badge">running</span>
+                        </button>
+                        <div v-if="modernBridgeVersions.length && legacyBridgeVersions.length" class="vlist-divider">legacy</div>
+                        <button
+                            v-for="v in legacyBridgeVersions"
+                            :key="v"
+                            type="button"
+                            :class="['vitem', { 'vitem--selected': bridges.selected === v }]"
+                            :disabled="bridges.statusColor === 'green'"
+                            @click="bridges.selected = v"
+                        >
+                            <span class="vitem-name">{{ v }}</span>
+                            <span v-if="bridges.statusColor === 'green' && bridges.selected === v" class="vitem-badge">running</span>
+                        </button>
+                    </div>
+
+                    <label class="field-label">Output</label>
+                    <label class="opt-tile" style="width: 100%" data-tooltip="Redirect bridge output to a log file instead of stdout">
+                        <input id="bridgeUseLogfile" type="checkbox" v-model="bridges.outputToLogfile" />
+                        <span class="opt-tile-name">Log to file</span>
+                    </label>
+
+                    <label class="field-label">On page load</label>
+                    <label class="opt-tile" style="width: 100%" data-tooltip="Remember the selected bridge version and start it automatically when the dashboard loads.">
+                        <input id="bridgeAutoStart" type="checkbox" v-model="bridges.autoStart" />
+                        <span class="opt-tile-name">Auto-start</span>
+                    </label>
+
+                    <label class="field-label">
+                        Status page
+                        <span class="field-label-note">· available while running</span>
+                    </label>
+                    <a
+                        class="btn btn--full"
+                        :href="bridges.statusColor === 'green' ? 'http://0.0.0.0:21328/status/' : '#'"
+                        :style="{ pointerEvents: bridges.statusColor === 'green' ? 'auto' : 'none', opacity: bridges.statusColor === 'green' ? 1 : .5 }"
+                        target="_blank"
+                        rel="noopener"
                     >
-                    <br/>
-                    <input
-                        type="text"
-                        placeholder="input seed"
-                        v-model="emulatorCommands.seed"
-                    />
-                    <button @click="emulatorSetup();">Load seed</button>
-                    <br/>
-                    <button @click="emulatorSetup('all');">
-                        Load ALL seed
+                        <svg viewBox="0 0 24 24"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+                        Open 0.0.0.0:21328/status/
+                    </a>
+
+                    <!-- Local Trezor Suite detection (advanced — collapsed by default) -->
+                    <button
+                        type="button"
+                        :class="['disclosure', { 'disclosure-on': suiteMountOpen }]"
+                        @click="suiteMountOpen = !suiteMountOpen"
+                    >
+                        <svg class="disclosure-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 6 15 12 9 18"/></svg>
+                        <span>Local Trezor Suite bridge</span>
+                        <span :class="['disclosure-note', { 'disclosure-note--ok': bridges.hasSuiteLocal }]">
+                            {{ bridges.hasSuiteLocal ? 'detected' : 'not mounted' }}
+                        </span>
                     </button>
-                    <button @click="emulatorSetup('academic');">
-                        Load ACADEMIC seed
+
+                    <div v-if="suiteMountOpen" class="disclosure-body">
+                        <div v-if="bridges.hasSuiteLocal" class="mount-card mount-card--ok">
+                            <svg class="mount-card-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 6L9 17l-5-5"/></svg>
+                            <div>
+                                <h4>Local Trezor Suite detected</h4>
+                                <p class="mount-card-desc">The <code>local-suite-node-bridge</code> version is available in the list above.</p>
+                            </div>
+                        </div>
+                        <div v-else class="mount-card">
+                            <div class="mount-card-hd">
+                                <h4>Local Trezor Suite not mounted</h4>
+                            </div>
+                            <p class="mount-card-desc">
+                                Mount a local Suite checkout to expose the <code>local-suite-node-bridge</code> version — useful when testing against a Suite feature branch.
+                            </p>
+                            <div class="mount-steps">
+                                <div class="mount-step">
+                                    <span class="mount-step-num">1</span>
+                                    <div class="mount-step-body">
+                                        <span class="mount-step-text">From the repo root, create a symlink to your local Suite checkout:</span>
+                                        <div class="code-row">
+                                            <code>ln -s [local-suite-path] trezor-suite</code>
+                                            <button
+                                                type="button"
+                                                :class="['copy-btn', { 'copy-btn--on': copyFlash === 'ln -s [local-suite-path] trezor-suite' }]"
+                                                @click="copyToClipboard('ln -s [local-suite-path] trezor-suite')"
+                                            >
+                                                <svg v-if="copyFlash !== 'ln -s [local-suite-path] trezor-suite'" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                                                <svg v-else viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 6L9 17l-5-5"/></svg>
+                                                <span>{{ copyFlash === 'ln -s [local-suite-path] trezor-suite' ? 'Copied' : 'Copy' }}</span>
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="mount-step">
+                                    <span class="mount-step-num">2</span>
+                                    <div class="mount-step-body">
+                                        <span class="mount-step-text">Restart the trezor-user-env server.</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="flyout-actions">
+                        <button
+                            v-if="bridges.statusColor !== 'green'"
+                            class="btn btn--primary"
+                            @click="bridgeStart()"
+                        >Start bridge</button>
+                        <button
+                            v-else
+                            class="btn btn--primary"
+                            disabled
+                        >Running</button>
+                        <button class="btn btn--danger" @click="bridgeStop()">Stop bridge</button>
+                    </div>
+                </div>
+            </aside>
+
+            <!-- §5 Tropic Square (conditional) -->
+            <aside :class="['flyout', { 'flyout--open': openFly === 'flyTropic' }]">
+                <div class="flyout-head">
+                    <div class="flyout-head-title">
+                        <h2>Tropic Square <span class="mono">· simulator</span></h2>
+                        <div class="flyout-head-desc">
+                            Simulator for the Tropic Square secure element.
+                            Required for Trezor Safe 7 — starts automatically when the T3W1 emulator is started.
+                        </div>
+                    </div>
+                    <button class="flyout-close" @click="closeFlyouts()" aria-label="Close panel" title="Close panel">
+                        <svg viewBox="0 0 24 24"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
                     </button>
                 </div>
-                <div>
-                    <button @click="emulatorResetDevice();">Reset</button>
-                    <button @click="emulatorResetDeviceShamir();">
-                        Reset with Shamir
-                    </button>
+                <div class="flyout-body">
 
+                    <label class="field-label">Status</label>
+                    <span :class="['status-pill', tropicStatusClass]">{{ tropic.status }}</span>
+
+                    <label class="field-label">Output</label>
+                    <label class="opt-tile" style="width: 100%" data-tooltip="Redirect Tropic output to a log file instead of stdout">
+                        <input id="tropicUseLogfile" type="checkbox" v-model="tropic.outputToLogfile" />
+                        <span class="opt-tile-name">Log to file</span>
+                    </label>
+
+                    <div class="flyout-actions">
+                        <button class="btn btn--primary" @click="tropicStart()">Start</button>
+                        <button class="btn btn--danger" @click="tropicStop()">Stop</button>
+                    </div>
                 </div>
-                <div>
-                    <button @click="readAndConfirmMnemonic();">
-                        Read and confirm mnemonic
-                    </button>
-                    <br/>
-                    <button @click="emulatorAllowUnsafe();">
-                        Allow unsafe (safety checks)
-                    </button>
-                </div>
-                <div>
-                    <label for="shares-input">Shares</label>
-                    <input
-                    id="shares-input"
-                    type="number"
-                    value="3"
-                    size="3"
-                    min="1"
-                    max="20"
-                    v-model="emulatorCommands.shamirShares"
-                    />
-                    <label for="threshold-input">Threshold</label>
-                    <input
-                    id="threshold-input"
-                    type="number"
-                    value="2"
-                    size="3"
-                    min="1"
-                    max="20"
-                    v-model="emulatorCommands.shamirThreshold"
-                    />
-                    <button @click="readAndConfirmMnemonicShamir();">
-                        Read and confirm mnemonic Shamir
+            </aside>
+
+            <!-- §6 Regtest -->
+            <aside :class="['flyout', { 'flyout--open': openFly === 'flyReg' }]">
+                <div class="flyout-head">
+                    <div class="flyout-head-title">
+                        <h2>Regtest</h2>
+                        <div class="flyout-head-desc">
+                            Local Bitcoin regression-test network (bitcoind + blockbook) for on-chain test scenarios.
+                        </div>
+                    </div>
+                    <button class="flyout-close" @click="closeFlyouts()" aria-label="Close panel" title="Close panel">
+                        <svg viewBox="0 0 24 24"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
                     </button>
                 </div>
-                <div>
-                    <button @click="emulatorSetBackupState();">
-                        Set backup state
+                <div class="flyout-body">
+
+                    <label class="field-label">Status</label>
+                    <span :class="['status-pill', regtestStatusClass]">{{ regtest.status }}</span>
+
+                    <label class="field-label">Mine blocks</label>
+                    <div style="display: grid; grid-template-columns: 1fr 2fr; gap: 8px">
+                        <input class="input" type="number" min="1" max="10000" v-model.number="regtest.mineBlocks" placeholder="1…10000" />
+                        <input class="input" type="text" v-model="regtest.mineAddress" placeholder="Optional miner address" />
+                    </div>
+                    <div class="field-hint">Count <b>1 – 10 000</b>, default <b>1</b>.</div>
+                    <button class="btn btn--full" style="margin-top: 10px" @click="regtestMine()">Mine</button>
+
+                    <label class="field-label">Send BTC</label>
+                    <div style="display: grid; grid-template-columns: 1fr 2fr; gap: 8px">
+                        <input class="input" type="number" step="any" v-model.number="regtest.sendAmount" placeholder="BTC" />
+                        <input class="input" type="text" v-model="regtest.sendAddress" placeholder="Destination address" />
+                    </div>
+                    <div class="field-hint">Default amount <b>10 BTC</b>.</div>
+                    <button class="btn btn--full" style="margin-top: 10px" @click="regtestSend()">Send</button>
+                </div>
+            </aside>
+
+            <!-- §7 Raw command -->
+            <aside :class="['flyout', { 'flyout--open': openFly === 'flyRaw' }]">
+                <div class="flyout-head">
+                    <div class="flyout-head-title">
+                        <h2>Server</h2>
+                        <div class="flyout-head-desc">
+                            Escape hatch. Send any JSON payload to the backend, ping for connectivity,
+                            close the connection, or request the server to exit.
+                        </div>
+                    </div>
+                    <button class="flyout-close" @click="closeFlyouts()" aria-label="Close panel" title="Close panel">
+                        <svg viewBox="0 0 24 24"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
                     </button>
                 </div>
-                <div>
-                    <button @click="emulatorGetFeatures();">
-                        Get features
-                    </button>
-                </div><div>
-                    <label for="tag-id-input">N4W1 tag</label>
-                    <input
-                    id="tag-id-input"
-                    type="number"
-                    value="1"
-                    size="3"
-                    min="1"
-                    max="100"
-                    v-model="emulatorCommands.n4w1TagId"
-                    />
-                    <button @click="n4w1Tap();">
-                        Tap
-                    </button>
-                    <button @click="n4w1Clear();">
-                        Clear
-                    </button>
+                <div class="flyout-body">
+                    <label class="field-label">Payload</label>
+                    <textarea id="server-input" class="textarea" rows="4" v-model="server.command"></textarea>
+                    <button class="btn btn--primary btn--full" style="margin-top: 10px" @click="sendServerCommand()">Send</button>
+
+                    <label class="field-label" style="margin-top: 20px">Server</label>
+                    <div class="row3">
+                        <button class="btn" @click="ping()">Ping server</button>
+                        <button class="btn" @click="closeWebsocket()">Close WebSocket</button>
+                        <button class="btn btn--danger" @click="exit()">Exit server</button>
+                    </div>
+
+                    <div class="info-block" style="margin-top: 16px">
+                        <span class="mono">ws://127.0.0.1:9001</span>
+                    </div>
                 </div>
-            </section>
-
-            <section>
-                <h3>Regtest</h3>
-
-                <div :style="{ color: regtest.statusColor }">
-                    <b>Status: <span>{{ regtest.status }}</span></b>
-                </div>
-
-                <label for="regtest-mine-blocks">Blocks</label>
-                <input
-                    id="regtest-mine-blocks"
-                    type="number"
-                    size="5"
-                    min="1"
-                    max="10000"
-                    v-model="regtest.mineBlocks"
-                />
-                <br />
-                <label for="regtest-mine-address"
-                    >Optional address of a miner</label
-                >
-                <input
-                    id="regtest-mine-address"
-                    size="62"
-                    v-model="regtest.mineAddress"
-                />
-                <br />
-                <button @click="regtestMine();">Mine regtest block(s)</button>
-
-                <hr />
-
-                <label for="regtest-send-amount">BTC amount</label>
-                <input
-                    id="regtest-send-amount"
-                    type="number"
-                    size="10"
-                    step="any"
-                    v-model="regtest.sendAmount"
-                />
-                <br />
-                <label for="regtest-send-address">Regtest address</label>
-                <input
-                    id="regtest-send-address"
-                    size="62"
-                    v-model="regtest.sendAddress"
-                />
-                <br />
-                <button @click="regtestSend();">
-                    Send regtest BTC to address
-                </button>
-            </section>
-
-            <section>
-                <h3>Server</h3>
-                <textarea
-                    id="server-input"
-                    rows="3"
-                    v-model="server.command"
-                ></textarea>
-                <br />
-                <button @click="sendServerCommand();">Send JSON</button>
-                <hr />
-                <button @click="ping();">Ping server</button>
-                <button @click="exit();">Exit server</button>
-                <button @click="closeWebsocket();">Close websocket</button>
-            </section>
+            </aside>
 
 
-            <section>
-                <h3>Event Log</h3>
-                <p
-                    v-for="log in logs"
-                    :key="log.text"
-                    :style="{ color: log.color }"
-                >
-                    {{ log.text }} <br />
-                </p>
-            </section>
-        </div>
+        </div><!-- #app -->
 
         <script src="js/vue.global.js"></script>
         <script type="text/javascript" src="js/index.js"></script>

--- a/src/dashboard/js/index.js
+++ b/src/dashboard/js/index.js
@@ -1,6 +1,17 @@
 const websocketUrl = "ws://localhost:9001/";
 const backgroundCheckPeriodMs = 500;
 
+// Safe localStorage wrapper — file:// in some browsers throws SecurityError.
+const store = {
+    get: function(key, fallback) {
+        try { return localStorage.getItem(key) || (fallback !== undefined ? fallback : null); }
+        catch (e) { return fallback !== undefined ? fallback : null; }
+    },
+    set: function(key, value) {
+        try { localStorage.setItem(key, value); } catch (e) { /* ignore */ }
+    },
+};
+
 const { createApp } = Vue;
 
 const app = createApp({
@@ -14,35 +25,46 @@ const app = createApp({
                 status: "unknown",
                 statusColor: "black",
                 hasSuiteLocal: false,
+                runningVersion: null,
+                autoStart: store.get('userEnvBridgeAutoStart') === 'true',
             },
             tropic: {
                 outputToLogfile: true,
                 status: "unknown",
                 statusColor: "black",
+                runningVersion: null,
             },
+            selectedEmulatorModel: store.get('userEnvSelectedModel', 'T3W1'),
             emulators: {
                 versions: {
                     T1B1: {
                         header: "Trezor One",
+                        inputType: "Buttons",
                         versions: [],
                     },
                     T2T1: {
                         header: "Trezor T",
+                        inputType: "Touch",
                         versions: [],
                     },
                     T3B1: {
                         header: "Trezor Safe 3",
+                        inputType: "Buttons",
                         versions: [],
                     },
                     T3T1: {
                         header: "Trezor Safe 5",
+                        inputType: "Touch",
                         versions: [],
                     },
                     T3W1: {
                         header: "Trezor Safe 7",
+                        inputType: "Touch",
                         versions: [],
                     },
                 },
+                runningModel: null,
+                runningVersion: null,
                 wipeDevice: false,
                 screenshotMode: false,
                 animations: false,
@@ -61,6 +83,9 @@ const app = createApp({
                 btcOnly: false,
             },
             emulatorDownloadMessage: "",
+            customFirmwareSource: "url",
+            customFirmwareOpen: false,
+            suiteMountOpen: false,
             emulatorCommands: {
                 seed: "",
                 shamirShares: 3,
@@ -89,27 +114,109 @@ const app = createApp({
                 header: "Notification",
                 isError: false,
             },
+            openFly: null,
+            theme: store.get('userEnvTheme', 'dark'),
+            copyFlash: null,
+            vncCacheBuster: Date.now(),
+            logFilter: 'all',
+            unseenLogs: 0,
+            wsReconnecting: false,
+            wsRetries: 0,
+            wsRetryTimer: null,
+            WS_MAX_RETRIES: 4,
         };
     },
     created() {
+        // Guard against stale / hand-edited localStorage values that would
+        // blow up templates like emulators.versions[selectedEmulatorModel].
+        if (!Object.prototype.hasOwnProperty.call(this.emulators.versions, this.selectedEmulatorModel)) {
+            this.selectedEmulatorModel = 'T3W1';
+        }
         this.setupWebSocket();
         setInterval(this.getBackgroundStatus, backgroundCheckPeriodMs);
     },
     mounted() {
+        document.documentElement.setAttribute('data-theme', this.theme);
         this.$nextTick(() => {
             document.getElementById("app").style.display = "block";
         });
-        // listen for Esc key and close the notification
+        // Esc: close popup first, then any open flyout.
         window.addEventListener("keydown", (event) => {
-            if (this.notifications.showPopup && event.key === "Escape") {
+            if (event.key !== "Escape") return;
+            if (this.notifications.showPopup) {
                 this.notifications.showPopup = false;
+            } else if (this.openFly) {
+                this.openFly = null;
             }
         });
+    },
+    computed: {
+        bridgeStatusClass() {
+            if (this.bridges.statusColor === 'green') return 'status-pill--ok';
+            if (this.bridges.statusColor === 'red') return 'status-pill--error';
+            return 'status-pill--unknown';
+        },
+        emulatorStatusClass() {
+            if (this.emulators.statusColor === 'green') return 'status-pill--ok';
+            if (this.emulators.statusColor === 'red') return 'status-pill--error';
+            return 'status-pill--unknown';
+        },
+        tropicStatusClass() {
+            if (this.tropic.statusColor === 'green') return 'status-pill--ok';
+            if (this.tropic.statusColor === 'red') return 'status-pill--error';
+            return 'status-pill--unknown';
+        },
+        regtestStatusClass() {
+            if (this.regtest.statusColor === 'green') return 'status-pill--ok';
+            if (this.regtest.statusColor === 'red') return 'status-pill--error';
+            return 'status-pill--unknown';
+        },
+        vncUrl() {
+            const bg = this.theme === 'dark' ? '#14171a' : '#f4f5f7';
+            return `http://localhost:6080/vnc_embed.html?background=${encodeURIComponent(bg)}&t=${this.vncCacheBuster}`;
+        },
+        showTropicSection() {
+            // Section §5: shown when T3W1 is selected or currently running.
+            return this.selectedEmulatorModel === 'T3W1' ||
+                   this.emulators.runningModel === 'T3W1';
+        },
+        emulatorHasButtons() {
+            const model = this.emulators.runningModel || this.selectedEmulatorModel;
+            return this.emulators.versions[model]?.inputType === 'Buttons';
+        },
+        modernBridgeVersions() {
+            // Spec §3: node-bridge (modern) group — anything not starting with "2."
+            return this.bridges.versions.filter(v => !v.startsWith('2.'));
+        },
+        legacyBridgeVersions() {
+            // Spec §3: legacy 2.x group.
+            return this.bridges.versions.filter(v => v.startsWith('2.'));
+        },
+        filteredLogs() {
+            if (this.logFilter === 'all') return this.logs;
+            return this.logs.filter(l => l.kind === this.logFilter);
+        },
+        logFilterOptions() {
+            return [
+                { k: 'all', label: 'All' },
+                { k: 'out', label: '→ Out' },
+                { k: 'ok',  label: '← Ok' },
+                { k: 'err', label: '✗ Err' },
+                { k: 'raw', label: '{ } Raw' },
+                { k: 'sys', label: 'System' },
+            ];
+        },
     },
     watch: {
         'emulatorUrl.url': function (newUrl) {
             this.updateModelFromUrl(newUrl);
-        }
+        },
+        selectedEmulatorModel(v) {
+            if (v) store.set('userEnvSelectedModel', v);
+        },
+        'bridges.autoStart'(v) {
+            store.set('userEnvBridgeAutoStart', v ? 'true' : 'false');
+        },
     },
     methods: {
         updateModelFromUrl(url) {
@@ -120,6 +227,12 @@ const app = createApp({
             });
         },
         setupWebSocket() {
+            // Clear any pending auto-retry that might fire while we're already connecting.
+            if (this.wsRetryTimer) {
+                clearTimeout(this.wsRetryTimer);
+                this.wsRetryTimer = null;
+            }
+
             this.ws = new WebSocket(websocketUrl);
 
             this.ws.onmessage = this.handleMessage;
@@ -129,9 +242,10 @@ const app = createApp({
                     `WebSocket connection Error. Event: ${JSON.stringify(
                         event
                     )}`,
-                    "red"
+                    "var(--red)"
                 );
-                this.showNotification("WebSocket error", true);
+                // Deliberately no blocking notification here — auto-retry will handle it
+                // and the user already sees the log entry + sidebar reconnect button.
             };
 
             this.ws.onclose = (event) => {
@@ -139,13 +253,28 @@ const app = createApp({
                     `WebSocket connection closed. Event: ${JSON.stringify(
                         event
                     )}`,
-                    "red"
+                    "var(--red)"
                 );
                 this.ws = null;
+                // Exponential backoff auto-retry, up to WS_MAX_RETRIES.
+                if (this.wsRetries < this.WS_MAX_RETRIES) {
+                    const delayMs = [1000, 2000, 5000, 10000][this.wsRetries] || 10000;
+                    this.wsRetries++;
+                    this.wsReconnecting = true;
+                    this.logEvent(
+                        `Reconnecting in ${Math.round(delayMs/1000)}s (attempt ${this.wsRetries}/${this.WS_MAX_RETRIES})…`,
+                        "var(--amber)"
+                    );
+                    this.wsRetryTimer = setTimeout(() => this.setupWebSocket(), delayMs);
+                } else {
+                    this.wsReconnecting = false;
+                }
             };
 
             this.ws.onopen = () => {
-                this.logEvent("WebSocket connection opened", "green");
+                this.logEvent("WebSocket connection opened", "var(--primary)");
+                this.wsRetries = 0;
+                this.wsReconnecting = false;
             };
         },
         handleMessage(event) {
@@ -154,7 +283,7 @@ const app = createApp({
             } catch (err) {
                 this.logEvent(
                     `Response received is not a valid JSON: ${event.data}`,
-                    "red"
+                    "var(--red)"
                 );
                 return;
             }
@@ -174,9 +303,9 @@ const app = createApp({
             let color;
             if ("success" in dataObject) {
                 if (dataObject.success) {
-                    color = "green";
+                    color = "var(--primary)";
                 } else {
-                    color = "red";
+                    color = "var(--red)";
                     this.showNotification(
                         "Some error happened, please look into Log below.",
                         true
@@ -219,11 +348,15 @@ const app = createApp({
                 this.bridges.hasSuiteLocal = dataObject.bridges.includes(
                     "local-suite-node-bridge"
                 );
+
+                // Wait one background-check tick so `bridges.statusColor`
+                // reflects the live state; then decide whether to auto-start.
+                setTimeout(() => this.maybeAutoStartBridge(), backgroundCheckPeriodMs + 100);
             }
         },
         sendMessage(msg) {
             if (this.isWaitingForResponse) {
-                this.logEvent("Waiting for response, please wait...", "red");
+                this.logEvent("Waiting for response, please wait...", "var(--red)");
                 return;
             }
 
@@ -231,18 +364,17 @@ const app = createApp({
                 this.showNotification("Please enter a message", true);
                 return;
             }
-            if (!this.ws) {
-                this.logEvent("WebSocket not connected", "red");
+            if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+                this.logEvent("WebSocket not connected", "var(--red)");
                 this.showNotification(
-                    "WebSocket not connected - trying to connect...",
+                    "WebSocket not connected – trying to connect…",
                     true
                 );
-                this.setupWebSocket();
-                this.sendMessage(msg);
+                if (!this.ws) this.setupWebSocket();
                 return;
             }
 
-            this.logEvent(`Request sent: ${JSON.stringify(msg)}`, "blue");
+            this.logEvent(`Request sent: ${JSON.stringify(msg)}`, "var(--blue)");
 
             const requestToSend = JSON.stringify(
                 Object.assign(msg, {
@@ -255,7 +387,9 @@ const app = createApp({
             this.isWaitingForResponse = true;
         },
         sendMessageOnBackground(json) {
-            if (!this.ws) {
+            // Skip if the socket isn't OPEN — sending on CONNECTING or CLOSING
+            // throws InvalidStateError and would drop the background-check.
+            if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
                 return;
             }
             this.ws.send(JSON.stringify(json));
@@ -265,13 +399,18 @@ const app = createApp({
                 type: "background-check",
             });
         },
-        showNotification(text, isError = false) {
+        showNotification(text, isError = true) {
+            // The error modal is only used for backend failures / validation blockers.
+            // `isError` is kept in the signature for backwards compatibility.
             this.notifications.text = text;
             this.notifications.showPopup = true;
             this.notifications.isError = isError;
-            this.notifications.header = isError ? "Error" : "Notification";
+            this.notifications.header = "Error";
         },
         bridgeStart() {
+            // Remember the version so the dashboard can auto-start it on the
+            // next load when the user has opted in (see `userEnvBridgeAutoStart`).
+            store.set('userEnvLastBridge', this.bridges.selected);
             this.sendMessage({
                 type: "bridge-start",
                 version: this.bridges.selected,
@@ -279,9 +418,24 @@ const app = createApp({
             });
         },
         bridgeStop() {
+            // Explicit stop clears the remembered version so a subsequent
+            // load doesn't bring back what the user just shut down.
+            store.set('userEnvLastBridge', '');
             this.sendMessage({
                 type: "bridge-stop",
             });
+        },
+        maybeAutoStartBridge() {
+            // Only fire once, after the `client` message delivers the live
+            // version list AND background-check has told us the bridge is
+            // not already running.
+            if (!this.bridges.autoStart) return;
+            const last = store.get('userEnvLastBridge');
+            if (!last) return;
+            if (!this.bridges.versions.includes(last)) return;
+            if (this.bridges.statusColor === 'green') return;
+            this.bridges.selected = last;
+            this.bridgeStart();
         },
         tropicStart() {
             this.sendMessage({
@@ -314,6 +468,8 @@ const app = createApp({
                 save_screenshots: this.emulators.screenshotMode,
                 show_animations: this.emulators.animations,
             });
+            // If the flyout is open, close it so the user sees the device stage come to life.
+            if (this.openFly === 'flyEmu') this.closeFlyouts();
         },
         emulatorStartFromUrl() {
             const url = this.emulatorUrl.url;
@@ -340,6 +496,8 @@ const app = createApp({
 
             this.emulatorDownloadMessage =
                 "Emulator started downloading, it may take a while...";
+            // Close the flyout so the user can see the download progress + device stage.
+            this.closeFlyouts();
         },
         emulatorStartFromBranch() {
             let branch = this.emulatorBranch.branch;
@@ -367,6 +525,7 @@ const app = createApp({
 
             this.emulatorDownloadMessage =
                 "Emulator started downloading, it may take a while...";
+            this.closeFlyouts();
         },
         reflectBackgroundSituationInGUI(dataObject) {
             if ("bridge_status" in dataObject) {
@@ -393,16 +552,23 @@ const app = createApp({
                     );
                 }
                 this.writeBridgeStatus(`Running - ${status.version}`, "green");
+                this.bridges.runningVersion = status.version || null;
             } else {
                 this.writeBridgeStatus("Stopped", "red");
+                this.bridges.runningVersion = null;
             }
         },
         reflectEmulatorSituation(status) {
             if (status.is_running) {
                 this.writeEmulatorStatus(
                     `Running - ${status.version}`,
-                    "green"
+                    "green"  // statusColor — used for CSS class, not inline style
                 );
+                const match = status.version && status.version.match(/\((\w+)\)$/);
+                this.emulators.runningModel = match ? match[1] : null;
+                this.emulators.runningVersion = status.version
+                    ? status.version.replace(/\s*\(\w+\)$/, "")
+                    : null;
                 if (!this.emulators.vncActive) {
                     this.emulators.vncActive = true;
                     this.$nextTick(() => this.reloadVnc());
@@ -410,13 +576,17 @@ const app = createApp({
             } else {
                 this.writeEmulatorStatus("Stopped", "red");
                 this.emulators.vncActive = false;
+                this.emulators.runningModel = null;
+                this.emulators.runningVersion = null;
             }
         },
         reflectTropicSituation(status) {
             if (status.is_running) {
                 this.writeTropicStatus(`Running - ${status.version}`, "green");
+                this.tropic.runningVersion = status.version || null;
             } else {
                 this.writeTropicStatus("Stopped", "red");
+                this.tropic.runningVersion = null;
             }
         },
         reflectRegtestSituation(is_running) {
@@ -452,7 +622,7 @@ const app = createApp({
                 return;
             }
 
-            this.logEvent(`Sent manually: ${command}`, "magenta");
+            this.logEvent(`Sent manually: ${command}`, "var(--amber)");
             this.sendMessage(JSON.parse(command));
             this.$nextTick(() => {
                 document.getElementById("server-input").focus();
@@ -523,19 +693,20 @@ const app = createApp({
             });
         },
         reloadVnc() {
-            const iframe = document.getElementById("vnc-iframe");
-            if (iframe) {
-                iframe.src = iframe.src;
-            }
+            this.vncCacheBuster = Date.now();
         },
         openVncPopup() {
             const w = 350;
             const h = 666;
-            const left = (screen.width - w) / 2;
-            const top = (screen.height - h) / 2;
+            const availW = (window.screen && window.screen.availWidth)  || window.innerWidth;
+            const availH = (window.screen && window.screen.availHeight) || window.innerHeight;
+            const left = Math.max(0, (availW - w) / 2);
+            const top  = Math.max(0, (availH - h) / 2);
             const popup = window.open("about:blank", "novnc-viewer", `popup=yes,width=${w},height=${h},left=${left},top=${top}`);
             if (popup) {
-                popup.location.href = "http://localhost:6080/vnc_embed.html";
+                popup.location.href = this.vncUrl;
+            } else {
+                this.showNotification("Popup blocked. Allow popups for this site to open the emulator in a separate window.", true);
             }
         },
         emulatorStop() {
@@ -561,25 +732,6 @@ const app = createApp({
                 type: "emulator-set-for-backup",
             });
         },
-        emulatorGetFeatures() {
-            this.sendMessage({
-                type: "emulator-get-features",
-            });
-        },
-        regtestMine() {
-            this.sendMessage({
-                type: "regtest-mine-blocks",
-                block_amount: this.regtest.mineBlocks,
-                address: this.regtest.mineAddress,
-            });
-        },
-        regtestSend() {
-            this.sendMessage({
-                type: "regtest-send-to-address",
-                btc_amount: this.regtest.sendAmount,
-                address: this.regtest.sendAddress,
-            });
-        },
         n4w1Tap() {
             this.sendMessage({
                 type: "emulator-n4w1-tap",
@@ -592,12 +744,137 @@ const app = createApp({
                 tag_id: this.emulatorCommands.n4w1TagId.toString(),
             });
         },
+        emulatorGetFeatures() {
+            this.sendMessage({
+                type: "emulator-get-features",
+            });
+        },
+        regtestMine() {
+            const blocks = Number(this.regtest.mineBlocks);
+            if (!blocks || blocks < 1 || blocks > 10000) {
+                this.showNotification("Block count must be between 1 and 10 000.", true);
+                return;
+            }
+            // Address is optional — the backend falls back to getnewaddress()
+            // when it's omitted. Only trim + send if the user provided one.
+            const payload = { type: "regtest-mine-blocks", block_amount: blocks };
+            const addr = (this.regtest.mineAddress || "").trim();
+            if (addr) payload.address = addr;
+            this.sendMessage(payload);
+        },
+        regtestSend() {
+            const amount = Number(this.regtest.sendAmount);
+            if (!amount || amount <= 0) {
+                this.showNotification("BTC amount must be greater than 0.", true);
+                return;
+            }
+            if (!this.regtest.sendAddress || !this.regtest.sendAddress.trim()) {
+                this.showNotification("Enter a destination address.", true);
+                return;
+            }
+            this.sendMessage({
+                type: "regtest-send-to-address",
+                btc_amount: amount,
+                address: this.regtest.sendAddress.trim(),
+            });
+        },
+        logKind(text, color) {
+            if (text.indexOf('Request sent') === 0) return 'out';
+            if (text.indexOf('Sent manually') === 0) return 'raw';
+            if (text.indexOf('Response received') === 0) {
+                if (color && color.indexOf('--red') !== -1) return 'err';
+                return 'ok';
+            }
+            if (text.indexOf('connection opened') !== -1) return 'ok';
+            if (color && color.indexOf('--red') !== -1) return 'err';
+            return 'sys';
+        },
         logEvent(text, color) {
+            const kind = this.logKind(text, color);
             const newLog = {
+                id: this.req_id + '_' + Date.now() + '_' + Math.random().toString(36).slice(2, 7),
                 text: `${currentTime()} - ${text}`,
                 color,
+                kind,
             };
+            // Track whether the user was already near the top before we prepend.
+            const el = this.$refs.logContainer;
+            const nearTop = !el || el.scrollTop < 60;
             this.logs.unshift(newLog);
+            // Cap log length so the DOM stays light for long sessions.
+            if (this.logs.length > 500) this.logs.length = 500;
+            // Auto-scroll only if the user was already near the top.
+            if (nearTop) {
+                this.$nextTick(() => { if (el) el.scrollTop = 0; });
+            } else {
+                this.unseenLogs = (this.unseenLogs || 0) + 1;
+            }
+        },
+        clearUnseen() {
+            this.unseenLogs = 0;
+            const el = this.$refs.logContainer;
+            if (el) el.scrollTop = 0;
+        },
+        onLogScroll() {
+            const el = this.$refs.logContainer;
+            if (el && el.scrollTop < 30) this.unseenLogs = 0;
+        },
+        openFlyout(id) {
+            // When switching directly from one flyout to another, suppress the
+            // slide transition so panels don't re-animate across the viewport —
+            // feels like an in-place content swap. First-open and final-close
+            // keep their slide.
+            if (this.openFly && this.openFly !== id) {
+                const root = document.documentElement;
+                root.classList.add('no-fly-transition');
+                this.openFly = id;
+                this.$nextTick(() => {
+                    // Force a reflow so the position change commits without a
+                    // transition, then re-enable transitions on the next frame.
+                    void root.offsetHeight;
+                    requestAnimationFrame(() => {
+                        root.classList.remove('no-fly-transition');
+                    });
+                });
+            } else {
+                this.openFly = id;
+            }
+        },
+        closeFlyouts() {
+            this.openFly = null;
+        },
+        toggleTheme() {
+            this.theme = this.theme === 'dark' ? 'light' : 'dark';
+            document.documentElement.setAttribute('data-theme', this.theme);
+            store.set('userEnvTheme', this.theme);
+        },
+        copyToClipboard(text) {
+            const done = () => {
+                this.copyFlash = text;
+                setTimeout(() => {
+                    if (this.copyFlash === text) this.copyFlash = null;
+                }, 2500);
+            };
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(text).then(done).catch(() => {
+                    this.showNotification("Clipboard access denied.", true);
+                });
+            } else {
+                // Fallback for older browsers / insecure contexts.
+                const ta = document.createElement("textarea");
+                ta.value = text;
+                ta.style.position = "fixed";
+                ta.style.top = "-1000px";
+                document.body.appendChild(ta);
+                ta.select();
+                try {
+                    document.execCommand("copy");
+                    done();
+                } catch (e) {
+                    this.showNotification("Copy not supported.", true);
+                }
+                document.body.removeChild(ta);
+            }
         },
     },
 });

--- a/src/emulator.py
+++ b/src/emulator.py
@@ -348,7 +348,7 @@ def start(
     # Verifying if the emulator is really running
     time.sleep(0.5)
 
-    vnc.start_capture()
+    vnc.start_capture(model=model)
     assert EMULATOR.process is not None
     if EMULATOR.process.poll() is not None:
         EMULATOR = None

--- a/src/vnc.py
+++ b/src/vnc.py
@@ -20,6 +20,14 @@ import helpers
 DISPLAY = ":42"
 NOVNC_URL = "http://localhost:6080/vnc_embed.html"
 
+# Optional per-model clip rectangle inside the emulator SDL window.
+# Format is x11vnc's -clip "WxH+X+Y", relative to the window when combined
+# with -id. No per-model clip rectangles are currently defined, so every
+# model uses a full-window capture. Populating an entry here would crop
+# the stream to that model's device shell, letting the iframe's
+# theme-coloured background replace the emulator's grey SDL padding.
+MODEL_CLIP: dict[str, str] = {}
+
 # Directory containing noVNC web files (index.html, vnc_embed.html, etc.)
 _NOVNC_SEARCH_PATHS = [
     "/usr/share/novnc",  # Debian/Docker
@@ -123,7 +131,7 @@ def start_display() -> None:
     time.sleep(0.5)
 
 
-def start_capture() -> None:
+def start_capture(model: str | None = None) -> None:
     """Start x11vnc, streaming only the emulator window by its ID."""
     global _x11vnc_process
 
@@ -138,6 +146,11 @@ def start_capture() -> None:
         cmd += ["-id", window_id]
     else:
         _log("Could not detect emulator window, serving full display")
+
+    clip = MODEL_CLIP.get(model) if model else None
+    if clip:
+        cmd += ["-clip", clip]
+        _log(f"Clipping stream to device shell: {clip}")
 
     _x11vnc_process = Popen(cmd, stdout=DEVNULL, stderr=DEVNULL)
     time.sleep(0.5)

--- a/src/vnc_embed.html
+++ b/src/vnc_embed.html
@@ -27,6 +27,18 @@
         const host = readQueryVariable('host', window.location.hostname);
         const port = readQueryVariable('port', window.location.port);
         const path = readQueryVariable('path', 'websockify');
+        const rawBg = readQueryVariable('background', '#808080');
+        // Only accept valid CSS hex literals: #RGB, #RGBA, #RRGGBB, #RRGGBBAA.
+        // Rejects arbitrary CSS values (e.g., url(...)) and malformed hex
+        // lengths like #12345 / #1234567 that the browser would silently drop.
+        const background = /^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(rawBg) ? rawBg : '#808080';
+
+        // Apply background to body and #screen so the canvas padding area
+        // matches the parent dashboard theme.
+        document.documentElement.style.background = background;
+        document.body.style.background = background;
+        const screenEl = document.getElementById('screen');
+        if (screenEl) screenEl.style.background = background;
 
         const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
         let url = proto + '://' + host;
@@ -37,7 +49,7 @@
             const rfb = new RFB(document.getElementById('screen'), url);
             rfb.scaleViewport = true;
             rfb.resizeSession = false;
-            rfb.background = "gray";
+            rfb.background = background;
 
             // once connected, resize the popup to match the remote desktop
             rfb.addEventListener('connect', () => {


### PR DESCRIPTION
## Summary

Rewrite the dashboard at `localhost:9002` as a card-based, theme-aware UI mapped 1:1 to the controller spec (see `docs/dashboard-overview.md` on the source branch). The structure is a 3-row shell grid: a full-width top bar, a sidebar on the left paired with the live device canvas, and the event log spanning the bottom row.

- **Top bar** — Trezor wordmark + "Emulator" label on the left, small spinner while waiting for a response, action buttons on the right (Emulator setup / Start / Stop / theme toggle).
- **Sidebar "Control"** — main header mirrors the Commands card h3; "Services" and "Tools" sub-headers mirror `.cmd-sec h5` (uppercase, trailing line). Services: Emulator, Bridge, Tropic Square (conditional on Trezor Safe 7), Regtest. Tools: Server. Each item opens a flyout for configuration; the running Bridge and Tropic Square inline their current version under the label. Hovering "Services" reveals a dots legend (running / stopped / unknown). A Reconnect button appears here only when the WebSocket drops.
- **Canvas** — Device card with the live VNC iframe (Reload / Pop out actions), Commands card grouped as Simulate (shown only for button-input models) / Setup — seed / Setup — lifecycle / Verify & debug / N4W1 NFC (T3W1), and an Event log with filterable kinds.
- **Flyouts** — Emulator (model grid, firmware list, launch-option tiles, custom firmware disclosure with URL/branch segmented control), Bridge (version list with modern/legacy split, local Suite bridge disclosure with a 2-step instruction + copy-to-clipboard, status-page link), Tropic Square, Regtest (mine / send BTC with spec-accurate defaults), Server (raw JSON payload + ping / close-WS / exit actions).

## Design system

- **Typography** — TT Satoshi throughout, JetBrains Mono for logs and code blocks (served via `@font-face` / `local()` — no remote font imports).
- **Themes** — Light and dark, toggled from the top bar and persisted to `localStorage`. All log colours use CSS variables so they stay readable in both themes. The VNC iframe src carries a matching `background` URL param so the canvas padding area tracks the theme.
- **Controls** — Tile-style on/off toggles replace iOS-style switches for launch options, passphrase, log destinations, and BTC-only. Numeric Shamir dials are fused with the Read & confirm Shamir button into a single grouped unit.

## Sidebar + flyout UX

- **Flyout anchoring** — panels slide in from behind the sidebar's right edge (sidebar sits above the flyout in z-index, plus a pseudo-element covers the 16 px viewport-left gap), so they appear to emerge from the sidebar rather than crossing the viewport. Inset layout (top: 72 px, bottom: 16 px, border-radius: 12 px) so the panel reads as an island.
- **Active item** — the sidebar item that spawned the open flyout is highlighted with a `primary-soft` background and a 2 px left accent rail.
- **Scoped backdrop** — dims only the canvas; top bar and sidebar remain legible and clickable, so the user can switch to a different module without closing first.
- **Instant swap between flyouts** — switching from one open panel to another uses a transient `.no-fly-transition` class on `<html>` to suppress the slide on both outgoing and incoming panels, making it feel like an in-place content swap. First open and final close still animate.
- **Accessibility** — every flyout close button is labelled; the disabled Tropic Square sidebar item uses `aria-disabled` + `@click.prevent` instead of the `disabled` attribute so its data-tooltip reason stays discoverable.

## Infrastructure

- `docker/compose.yml` bind-mounts `src/dashboard/` and `src/vnc_embed.html` so local edits are served by the container without rebuilding the image.
- `src/main.py` auto-starts the default bridge (or the first available one) on server boot, so the dashboard comes up with host connectivity ready. Opt out with `TREZOR_USER_ENV_NO_BRIDGE_AUTOSTART=1` (the controller test fixture sets this so start/stop tests see a clean slate).
- `src/vnc.py` gains an (optional) `MODEL_CLIP: dict[str, str]` plus a `model` kwarg on `start_capture()`. When an entry is populated, x11vnc is started with `-clip WxH+X+Y` to crop the stream to that model's device shell. No per-model rectangles are defined yet, so all models use a full-window capture — no behaviour change until values are added.
- `src/emulator.py` forwards the running model into `vnc.start_capture()`.
- `src/vnc_embed.html` reads a `background` query parameter and applies it to `html`, `body`, `#screen`, and `rfb.background` so the VNC padding area adopts the host page theme. The value is validated against `#RGB` / `#RGBA` / `#RRGGBB` / `#RRGGBBAA`; anything else falls back to `#808080` so arbitrary CSS (e.g. `url(...)`) can't be injected.

## Resilience

- WebSocket auto-reconnect with exponential backoff and a visible Reconnect button.
- `sendMessage()` and `sendMessageOnBackground()` both guard on `readyState === WebSocket.OPEN`, so background checks don't throw `InvalidStateError` during reconnects.
- `selectedEmulatorModel` is validated against `emulators.versions` on startup; stale / hand-edited localStorage values fall back to `T3W1`.

## Commits

- `chore(docker): mount dashboard and vnc_embed for local dev`
- `feat(server): auto-start bridge on boot, scaffold per-model VNC clip, theme-aware embed background`
- `feat(dashboard): redesign with Trezor Suite design language`

## Test plan

- [ ] `./run.sh` starts the stack and opens `http://localhost:9002` with the new dashboard
- [ ] Bridge auto-starts on server boot; sidebar shows the running bridge version under "Bridge" within ~500 ms. Launching with `TREZOR_USER_ENV_NO_BRIDGE_AUTOSTART=1` skips the auto-start
- [ ] `make test` runs the controller tests to completion (they rely on the skip env var being set by the test fixture)
- [ ] Sidebar Connection row is hidden when WS is connected; a Reconnect button appears when the WS drops and restores the connection when clicked
- [ ] Open Emulator flyout → pick each of the 5 models → firmware dropdown is populated from the backend and the device card header reflects the running model
- [ ] Launch options (Animations, Wipe on start, Log to file, Screenshot mode) toggle visually and are respected on `emulator-start`
- [ ] Custom firmware disclosure — URL tab populates model via URL inference, branch tab sends `btc_only` flag correctly, download banner shows while a binary is being fetched
- [ ] Bridge flyout — modern and legacy 2.x versions are grouped; Local Suite bridge disclosure shows "detected" when mounted and a two-step instruction + working copy-to-clipboard otherwise; status-page link opens `0.0.0.0:21328/status/` only when bridge is running
- [ ] Tropic Square flyout appears only when T3W1 is selected or running; sidebar item shows its version label when running; disabled state is announced by screen readers via `aria-disabled`
- [ ] Regtest flyout — mine (count 1–10 000, default 1, reward address optional) and send (default 10 BTC) both hit the backend
- [ ] Server flyout — raw JSON payload with prefilled `{"type": "specify"}` sends correctly; ping / close WS / exit actions work
- [ ] Commands card — on touch models (T2T1, T3T1, T3W1) the Simulate section is hidden; on button models (T1B1, T3B1) Yes/No work. All 3 seed presets (all / academic / custom), Wipe / Reset / Shamir, read-and-confirm mnemonic, read-and-confirm Shamir (shares/threshold), Get features, Set backup state, Safety checks off
- [ ] N4W1 NFC tap/clear works (T3W1), tag ID dial clamps to 1–100
- [ ] Flyout anchoring — open from closed: panel emerges from behind the sidebar. Switching from one flyout to another: content swaps without a slide. Closing: panel retreats behind the sidebar. Sidebar items remain clickable while a panel is open
- [ ] Hover the "Services" sub-header in the sidebar → dots legend appears to its right
- [ ] Theme toggle flips dark ↔ light and persists across reloads; VNC background adopts the theme on reload
- [ ] Event log — filters are functional (All / Out / Ok / Err / Raw / System), Clear empties the list, "N new events" chip shows when scroll is offscreen, colours remain readable in both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)