### PR TITLE
fix(dashboard): address PR #363 review comments + log panel UX improvements

### DIFF
--- a/src/dashboard/css/index.css
+++ b/src/dashboard/css/index.css
@@ -353,10 +353,12 @@ code { font-family: "JetBrains Mono", ui-monospace, monospace; font-size: .92em;
 }
 .topbar-logo {
     display: block;
-    height: 16px;
+    height: 14px;
     width: auto;
     fill: var(--text);
     flex-shrink: 0;
+    align-self: center;
+    margin-top: -3px;
 }
 .topbar-brand-sep {
     width: 1px;
@@ -367,9 +369,10 @@ code { font-family: "JetBrains Mono", ui-monospace, monospace; font-size: .92em;
 .topbar-brand-name {
     font-size: 13px;
     font-weight: 500;
-    line-height: 1;
+    line-height: 14px;
     color: var(--muted);
     letter-spacing: .01em;
+    align-self: center;
 }
 .topbar-theme { color: var(--muted); }
 .topbar-theme:hover { color: var(--primary); }
@@ -467,11 +470,13 @@ code { font-family: "JetBrains Mono", ui-monospace, monospace; font-size: .92em;
     padding: 16px 16px 16px 16px;
     display: grid;
     grid-template-columns: 1fr 325px;
-    grid-template-rows: minmax(0, 1fr) 240px;
-    gap: 16px;
+    grid-template-rows: minmax(0, 1fr) 16px var(--log-bottom-height, 240px);
+    gap: 0;
+    row-gap: 0;
+    column-gap: 16px;
     min-width: 0;
     min-height: 0;
-    overflow: hidden;
+    overflow: visible;
 }
 
 .card {
@@ -539,7 +544,7 @@ code { font-family: "JetBrains Mono", ui-monospace, monospace; font-size: .92em;
 .card-head-right { display: flex; gap: 4px; align-items: center; }
 
 /* ============ DEVICE CARD (VNC) ============ */
-.device-card { grid-column: 1; grid-row: 1; }
+.device-card { grid-column: 1; grid-row: 1; margin-bottom: 0; }
 
 .device-stage {
     flex: 1;
@@ -624,7 +629,7 @@ code { font-family: "JetBrains Mono", ui-monospace, monospace; font-size: .92em;
 /* ============ COMMANDS CARD ============ */
 .cmd-card {
     grid-column: 2;
-    grid-row: 1 / span 2;
+    grid-row: 1 / span 3;
     /* Allow tooltips inside to escape the card boundary */
     overflow: visible;
 }
@@ -929,7 +934,11 @@ code { font-family: "JetBrains Mono", ui-monospace, monospace; font-size: .92em;
 }
 
 /* ============ LOG CARD ============ */
-.log-card { grid-column: 1; grid-row: 2; position: relative; }
+/* Log card needs visible overflow so tooltips in the header aren't clipped */
+.log-card { grid-column: 1; grid-row: 3; position: relative; overflow: visible; }
+/* Re-clip the entries area so logs don't spill out */
+.log-card .log-entries { overflow: auto; }
+.log-card .card-head { border-radius: 12px 12px 0 0; }
 .log-tools {
     display: flex;
     align-items: center;
@@ -954,6 +963,107 @@ code { font-family: "JetBrains Mono", ui-monospace, monospace; font-size: .92em;
     font-weight: 500;
 }
 .log-tools-clear:hover { color: var(--red); background: var(--red-soft); }
+.log-tools-expand {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    padding: 5px;
+    color: var(--muted);
+    cursor: pointer;
+    border-radius: 6px;
+    background: transparent;
+    border: 0;
+}
+.log-tools-expand svg { width: 100%; height: 100%; }
+.log-tools-expand:hover { color: var(--text); background: var(--card-2); }
+.log-tools-side {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    padding: 5px;
+    color: var(--muted);
+    cursor: pointer;
+    border-radius: 6px;
+    background: transparent;
+    border: 0;
+}
+.log-tools-side svg { width: 100%; height: 100%; }
+.log-tools-side:hover { color: var(--text); background: var(--card-2); }
+.canvas--log-side {
+    grid-template-columns: var(--log-side-width, 420px) 16px 1fr 325px;
+    grid-template-rows: 1fr;
+    column-gap: 0;
+    overflow: visible;
+}
+.canvas--log-side .log-card {
+    grid-column: 1;
+    grid-row: 1;
+}
+.canvas--log-side .log-side-handle {
+    grid-column: 2;
+    grid-row: 1;
+    cursor: col-resize;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10;
+}
+.canvas--log-side .log-side-handle::after {
+    content: '';
+    width: 2px;
+    height: 40px;
+    border-radius: 999px;
+    background: var(--border);
+    transition: background .15s;
+}
+.canvas--log-side .log-side-handle:hover::after,
+.canvas--log-side .log-side-handle.dragging::after {
+    background: var(--primary);
+}
+.canvas--log-side:has(.log-side-handle.dragging) {
+    user-select: none;
+}
+.log-bottom-handle {
+    grid-column: 1;
+    grid-row: 2;
+    cursor: row-resize;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 16px;
+}
+.log-bottom-handle::after {
+    content: '';
+    width: 40px;
+    height: 2px;
+    border-radius: 999px;
+    background: var(--border);
+    transition: background .15s;
+}
+.log-bottom-handle:hover::after,
+.log-bottom-handle.dragging::after { background: var(--primary); }
+.canvas:has(.log-bottom-handle.dragging) { user-select: none; }
+.canvas--log-side .device-card {
+    grid-column: 3;
+    grid-row: 1;
+}
+.canvas--log-side .cmd-card {
+    grid-column: 4;
+    grid-row: 1;
+    margin-left: 16px;
+}
+.log-card--expanded {
+    grid-row: 1 / span 2 !important;
+    display: flex;
+    flex-direction: column;
+    overflow: visible !important;
+}
 
 .log-entries {
     flex: 1;
@@ -977,29 +1087,95 @@ code { font-family: "JetBrains Mono", ui-monospace, monospace; font-size: .92em;
     text-align: center;
 }
 
-.log-filters {
+.log-toolbar {
     display: flex;
     align-items: center;
     gap: 4px;
-    flex-wrap: wrap;
+    flex-shrink: 1;
+    min-width: 0;
 }
-.log-filter {
+.log-toolbar-sep {
+    width: 1px;
+    height: 14px;
+    background: var(--border);
+    flex-shrink: 0;
+    margin: 0 2px;
+}
+.log-filter-dropdown { position: relative; }
+.log-filter-toggle {
+    display: flex;
+    align-items: center;
+    gap: 5px;
     padding: 3px 9px;
     border: 0;
     border-radius: 999px;
     background: transparent;
     color: var(--muted);
     font-family: inherit;
-    font-size: 11px;
+    font-size: 12px;
     font-weight: 500;
     cursor: pointer;
     transition: background .12s, color .12s;
+    flex-shrink: 0;
 }
-.log-filter:hover { color: var(--text); background: var(--card-2); }
-.log-filter.log-filter--on {
-    background: var(--primary-soft);
-    color: var(--primary);
+.log-filter-toggle:hover,
+.log-filter-toggle--active { color: var(--text); background: var(--card-2); }
+.log-filter-dot {
+    width: 5px;
+    height: 5px;
+    border-radius: 999px;
+    background: var(--primary);
+    flex-shrink: 0;
 }
+.log-filter-menu {
+    position: absolute;
+    top: calc(100% + 6px);
+    left: 0;
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 4px;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    z-index: 50;
+    box-shadow: 0 8px 24px -8px rgba(0,0,0,.35);
+    min-width: 120px;
+}
+.log-filter-option {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 5px 10px;
+    border: 0;
+    border-radius: 5px;
+    background: transparent;
+    color: var(--muted);
+    font-family: inherit;
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    text-align: left;
+    transition: background .1s, color .1s;
+}
+.log-filter-option:hover { background: var(--card-2); color: var(--text); }
+.log-filter-option--on { color: var(--text); }
+.log-filter-check {
+    width: 14px;
+    height: 14px;
+    border: 1.5px solid var(--border);
+    border-radius: 3px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+.log-filter-option--on .log-filter-check {
+    background: var(--primary);
+    border-color: var(--primary);
+    color: #fff;
+}
+.log-filter-check svg { width: 10px; height: 10px; }
 
 .log-unseen-chip {
     position: absolute;
@@ -1375,7 +1551,7 @@ button[data-tooltip]::after {
     opacity: 0;
     pointer-events: none;
     transition: opacity .15s ease 0s, transform .15s ease 0s;
-    z-index: 20;
+    z-index: 300;
 }
 :root[data-theme="light"] button[data-tooltip]::after {
     box-shadow: 0 10px 28px -10px rgba(16,18,21,.18);
@@ -1392,6 +1568,14 @@ button[data-tooltip][data-tooltip-pos="right"]::after {
 }
 button[data-tooltip][data-tooltip-pos="right"]:hover::after {
     transform: translateX(0) translateY(0);
+}
+button[data-tooltip][data-tooltip-pos="bottom"]::after {
+    bottom: auto;
+    top: calc(100% + 8px);
+    transform: translateX(-50%) translateY(-4px);
+}
+button[data-tooltip][data-tooltip-pos="bottom"]:hover::after {
+    transform: translateX(-50%) translateY(0);
 }
 
 /* Label tooltip — uses ::before so ::after stays free for the toggle switch */
@@ -1419,7 +1603,7 @@ label[data-tooltip]::before {
     opacity: 0;
     pointer-events: none;
     transition: opacity .15s ease 0s, transform .15s ease 0s;
-    z-index: 20;
+    z-index: 300;
 }
 :root[data-theme="light"] label[data-tooltip]::before {
     box-shadow: 0 10px 28px -10px rgba(16,18,21,.18);
@@ -1940,6 +2124,7 @@ label[data-tooltip]:hover::before {
 @media (max-width: 1280px) {
     :root { --sb-col: 200px; }
     .canvas { grid-template-columns: 1fr 300px; }
+    .log-tools-side { display: none; }
 }
 @media (max-width: 1080px) {
     :root { --sb-col: 72px; }
@@ -1947,10 +2132,12 @@ label[data-tooltip]:hover::before {
     .sidebar { padding: 12px 8px; }
     .canvas {
         grid-template-columns: 1fr;
-        grid-template-rows: 1fr 1fr 200px;
+        grid-template-rows: 1fr 1fr 16px 200px;
+        column-gap: 0;
     }
     .cmd-card { grid-column: 1; grid-row: 2; }
-    .log-card { grid-column: 1; grid-row: 3; }
+    .log-bottom-handle { grid-column: 1; grid-row: 3; }
+    .log-card { grid-column: 1; grid-row: 4; }
     .models { grid-template-columns: repeat(3, 1fr); }
     .topbar { padding: 0 12px; }
     .topbar-actions .btn { padding: 6px 10px; font-size: 11px; }

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -196,7 +196,10 @@
 
                 <!-- ========== MAIN ========== -->
                 <!-- Canvas -->
-                    <div class="canvas">
+                    <div :class="['canvas', { 'canvas--log-side': logSide }]">
+
+                        <!-- Drag handle for log side panel resize (only active in side mode) -->
+                        <div v-if="logSide" class="log-side-handle" @mousedown="startLogResize"></div>
 
                         <!-- §8 Device display (VNC live view) -->
                         <section class="card device-card">
@@ -414,21 +417,60 @@
                             </div>
                         </section>
 
+                        <!-- Drag handle for log bottom resize (only active in default/bottom mode) -->
+                        <div v-if="!logSide" class="log-bottom-handle" @mousedown="startLogBottomResize"></div>
+
                         <!-- §10 Event log -->
-                        <section class="card log-card">
+                        <section :class="['card', 'log-card', { 'log-card--expanded': logExpanded, 'log-card--side': logSide }]">
                             <div class="card-head">
                                 <h3>
                                     Event log
                                     <span class="card-head-tag">{{ logs.length }} events</span>
                                 </h3>
-                                <div class="card-head-right log-filters">
+                                <div class="card-head-right log-toolbar">
+                                    <div class="log-filter-dropdown">
+                                        <button
+                                            class="log-filter-toggle"
+                                            :class="{ 'log-filter-toggle--active': logFiltersActive }"
+                                            @click.stop="logFilterOpen = !logFilterOpen"
+                                            data-tooltip="Filter log entries"
+                                        >Filters<span v-if="logFiltersActive" class="log-filter-dot"></span></button>
+                                        <div v-if="logFilterOpen" class="log-filter-menu" @click.stop>
+                                            <button
+                                                v-for="f in logFilterOptions"
+                                                :key="f.k"
+                                                :class="['log-filter-option', { 'log-filter-option--on': logFilters.has(f.k) }]"
+                                                :data-tooltip="f.tip"
+                                                data-tooltip-pos="bottom"
+                                                @click="toggleFilter(f.k)"
+                                            >
+                                                <span class="log-filter-check">
+                                                    <svg v-if="logFilters.has(f.k)" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg>
+                                                </span>
+                                                {{ f.label }}
+                                            </button>
+                                        </div>
+                                    </div>
+                                    <span class="log-toolbar-sep"></span>
+                                    <button class="log-tools-clear" @click="logs = []; unseenLogs = 0" data-tooltip="Clear all log entries">Clear</button>
                                     <button
-                                        v-for="f in logFilterOptions"
-                                        :key="f.k"
-                                        :class="['log-filter', { 'log-filter--on': logFilter === f.k }]"
-                                        @click="logFilter = f.k"
-                                    >{{ f.label }}</button>
-                                    <button class="log-tools-clear" @click="logs = []; unseenLogs = 0">Clear</button>
+                                        class="log-tools-expand"
+                                        @click="logExpanded = !logExpanded"
+                                        :aria-label="logExpanded ? 'Collapse log panel' : 'Expand log panel'"
+                                        :data-tooltip="logExpanded ? 'Collapse' : 'Expand to fullscreen'"
+                                    >
+                                        <svg v-if="!logExpanded" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/></svg>
+                                        <svg v-else viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="4 14 10 14 10 20"/><polyline points="20 10 14 10 14 4"/><line x1="10" y1="14" x2="3" y2="21"/><line x1="21" y1="3" x2="14" y2="10"/></svg>
+                                    </button>
+                                    <button
+                                        class="log-tools-side"
+                                        @click="logSide = !logSide"
+                                        :aria-label="logSide ? 'Detach log from side' : 'Dock log to side'"
+                                        :data-tooltip="logSide ? 'Return to default layout' : 'Dock log panel to left side'"
+                                    >
+                                        <svg v-if="!logSide" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="9" y1="3" x2="9" y2="21"/></svg>
+                                        <svg v-else viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="3" y1="15" x2="21" y2="15"/></svg>
+                                    </button>
                                 </div>
                             </div>
                             <button
@@ -443,7 +485,7 @@
                                     :style="{ color: log.color }"
                                 >{{ log.text }}</p>
                                 <div v-if="!filteredLogs.length" class="log-empty">
-                                    <span v-if="logFilter !== 'all' && logs.length">No {{ logFilter }} events yet.</span>
+                                    <span v-if="logFiltersActive && logs.length">No matching events for the current filter selection.</span>
                                     <span v-else>No events yet. Start the bridge or emulator to see outbound requests and backend responses.</span>
                                 </div>
                             </div>

--- a/src/dashboard/js/index.js
+++ b/src/dashboard/js/index.js
@@ -1,5 +1,6 @@
 const websocketUrl = "ws://localhost:9001/";
 const backgroundCheckPeriodMs = 500;
+const WS_MAX_RETRIES = 4;
 
 // Safe localStorage wrapper — file:// in some browsers throws SecurityError.
 const store = {
@@ -115,15 +116,21 @@ const app = createApp({
                 isError: false,
             },
             openFly: null,
+            logExpanded: false,
+            logSide: store.get('userEnvLogSide') === 'true',
+            logSideWidth: parseInt(store.get('userEnvLogSideWidth', '420'), 10),
+            logBottomHeight: parseInt(store.get('userEnvLogBottomHeight', '240'), 10),
+            logFilters: new Set(
+                (store.get('userEnvLogFilters', 'out,ok,err,raw,sys')).split(',').filter(Boolean)
+            ),
+            logFilterOpen: false,
             theme: store.get('userEnvTheme', 'dark'),
             copyFlash: null,
             vncCacheBuster: Date.now(),
-            logFilter: 'all',
             unseenLogs: 0,
             wsReconnecting: false,
             wsRetries: 0,
             wsRetryTimer: null,
-            WS_MAX_RETRIES: 4,
         };
     },
     created() {
@@ -139,6 +146,12 @@ const app = createApp({
         document.documentElement.setAttribute('data-theme', this.theme);
         this.$nextTick(() => {
             document.getElementById("app").style.display = "block";
+        });
+        document.documentElement.style.setProperty('--log-side-width', this.logSideWidth + 'px');
+        document.documentElement.style.setProperty('--log-bottom-height', this.logBottomHeight + 'px');
+        // Close filter dropdown on outside click.
+        document.addEventListener('click', (e) => {
+            if (!e.target.closest('.log-filter-dropdown')) this.logFilterOpen = false;
         });
         // Esc: close popup first, then any open flyout.
         window.addEventListener("keydown", (event) => {
@@ -193,17 +206,18 @@ const app = createApp({
             return this.bridges.versions.filter(v => v.startsWith('2.'));
         },
         filteredLogs() {
-            if (this.logFilter === 'all') return this.logs;
-            return this.logs.filter(l => l.kind === this.logFilter);
+            return this.logs.filter(l => this.logFilters.has(l.kind));
+        },
+        logFiltersActive() {
+            return this.logFilters.size < 5;
         },
         logFilterOptions() {
             return [
-                { k: 'all', label: 'All' },
-                { k: 'out', label: '→ Out' },
-                { k: 'ok',  label: '← Ok' },
-                { k: 'err', label: '✗ Err' },
-                { k: 'raw', label: '{ } Raw' },
-                { k: 'sys', label: 'System' },
+                { k: 'out', label: 'Out',    tip: 'Outbound requests sent to the backend' },
+                { k: 'ok',  label: 'Ok',     tip: 'Successful responses from the backend' },
+                { k: 'err', label: 'Err',    tip: 'Error responses and failures' },
+                { k: 'raw', label: 'Raw',    tip: 'Raw WebSocket messages (sent manually)' },
+                { k: 'sys', label: 'System', tip: 'Internal events: connect, disconnect, retry' },
             ];
         },
     },
@@ -216,6 +230,9 @@ const app = createApp({
         },
         'bridges.autoStart'(v) {
             store.set('userEnvBridgeAutoStart', v ? 'true' : 'false');
+        },
+        logSide(v) {
+            store.set('userEnvLogSide', v ? 'true' : 'false');
         },
     },
     methods: {
@@ -257,12 +274,12 @@ const app = createApp({
                 );
                 this.ws = null;
                 // Exponential backoff auto-retry, up to WS_MAX_RETRIES.
-                if (this.wsRetries < this.WS_MAX_RETRIES) {
+                if (this.wsRetries < WS_MAX_RETRIES) {
                     const delayMs = [1000, 2000, 5000, 10000][this.wsRetries] || 10000;
                     this.wsRetries++;
                     this.wsReconnecting = true;
                     this.logEvent(
-                        `Reconnecting in ${Math.round(delayMs/1000)}s (attempt ${this.wsRetries}/${this.WS_MAX_RETRIES})…`,
+                        `Reconnecting in ${Math.round(delayMs/1000)}s (attempt ${this.wsRetries}/${WS_MAX_RETRIES})…`,
                         "var(--amber)"
                     );
                     this.wsRetryTimer = setTimeout(() => this.setupWebSocket(), delayMs);
@@ -809,6 +826,64 @@ const app = createApp({
             } else {
                 this.unseenLogs = (this.unseenLogs || 0) + 1;
             }
+        },
+        startLogBottomResize(e) {
+            e.preventDefault();
+            const handle = e.currentTarget;
+            const startY = e.clientY;
+            const startHeight = this.logBottomHeight;
+            handle.classList.add('dragging');
+            document.body.style.cursor = 'row-resize';
+            document.body.style.pointerEvents = 'none';
+            handle.style.pointerEvents = 'auto';
+            const onMove = (ev) => {
+                const h = Math.max(100, Math.min(startHeight - (ev.clientY - startY), window.innerHeight - 300));
+                this.logBottomHeight = h;
+                document.documentElement.style.setProperty('--log-bottom-height', h + 'px');
+            };
+            const onUp = () => {
+                handle.classList.remove('dragging');
+                document.body.style.cursor = '';
+                document.body.style.pointerEvents = '';
+                handle.style.pointerEvents = '';
+                store.set('userEnvLogBottomHeight', String(this.logBottomHeight));
+                document.removeEventListener('mousemove', onMove);
+                document.removeEventListener('mouseup', onUp);
+            };
+            document.addEventListener('mousemove', onMove);
+            document.addEventListener('mouseup', onUp);
+        },
+        startLogResize(e) {
+            e.preventDefault();
+            const handle = e.currentTarget;
+            const startX = e.clientX;
+            const startWidth = this.logSideWidth;
+            handle.classList.add('dragging');
+            document.body.style.cursor = 'col-resize';
+            document.body.style.pointerEvents = 'none';
+            handle.style.pointerEvents = 'auto';
+            const onMove = (ev) => {
+                const w = Math.max(390, Math.min(startWidth + ev.clientX - startX, 1150));
+                this.logSideWidth = w;
+                document.documentElement.style.setProperty('--log-side-width', w + 'px');
+            };
+            const onUp = () => {
+                handle.classList.remove('dragging');
+                document.body.style.cursor = '';
+                document.body.style.pointerEvents = '';
+                handle.style.pointerEvents = '';
+                store.set('userEnvLogSideWidth', String(this.logSideWidth));
+                document.removeEventListener('mousemove', onMove);
+                document.removeEventListener('mouseup', onUp);
+            };
+            document.addEventListener('mousemove', onMove);
+            document.addEventListener('mouseup', onUp);
+        },
+        toggleFilter(k) {
+            const f = new Set(this.logFilters);
+            if (f.has(k)) { f.delete(k); } else { f.add(k); }
+            this.logFilters = f;
+            store.set('userEnvLogFilters', [...f].join(','));
         },
         clearUnseen() {
             this.unseenLogs = 0;

--- a/src/emulator.py
+++ b/src/emulator.py
@@ -348,7 +348,7 @@ def start(
     # Verifying if the emulator is really running
     time.sleep(0.5)
 
-    vnc.start_capture(model=model)
+    vnc.start_capture()
     assert EMULATOR.process is not None
     if EMULATOR.process.poll() is not None:
         EMULATOR = None

--- a/src/vnc.py
+++ b/src/vnc.py
@@ -20,14 +20,6 @@ import helpers
 DISPLAY = ":42"
 NOVNC_URL = "http://localhost:6080/vnc_embed.html"
 
-# Optional per-model clip rectangle inside the emulator SDL window.
-# Format is x11vnc's -clip "WxH+X+Y", relative to the window when combined
-# with -id. No per-model clip rectangles are currently defined, so every
-# model uses a full-window capture. Populating an entry here would crop
-# the stream to that model's device shell, letting the iframe's
-# theme-coloured background replace the emulator's grey SDL padding.
-MODEL_CLIP: dict[str, str] = {}
-
 # Directory containing noVNC web files (index.html, vnc_embed.html, etc.)
 _NOVNC_SEARCH_PATHS = [
     "/usr/share/novnc",  # Debian/Docker
@@ -131,7 +123,7 @@ def start_display() -> None:
     time.sleep(0.5)
 
 
-def start_capture(model: str | None = None) -> None:
+def start_capture() -> None:
     """Start x11vnc, streaming only the emulator window by its ID."""
     global _x11vnc_process
 
@@ -146,11 +138,6 @@ def start_capture(model: str | None = None) -> None:
         cmd += ["-id", window_id]
     else:
         _log("Could not detect emulator window, serving full display")
-
-    clip = MODEL_CLIP.get(model) if model else None
-    if clip:
-        cmd += ["-clip", clip]
-        _log(f"Clipping stream to device shell: {clip}")
 
     # x11vnc refuses to start when WAYLAND_DISPLAY is set, even when targeting
     # an Xvfb display. Strip it so x11vnc connects to DISPLAY instead.


### PR DESCRIPTION
## Summary

Addresses all actionable human reviewer comments from PR #363 and improves the log panel UX.

### PR #363 review fixes
- **vdovhanych** — `docker/compose.yml`: debug bind mounts were already clean (never committed)
- **OriginalEveres / martykan** — Remove dead `MODEL_CLIP` scaffold from `src/vnc.py`; the dict was empty, the approach was contested, clipping deferred to a dedicated follow-up
- **OriginalEveres** — Move `WS_MAX_RETRIES` from Vue reactive `data()` to a module-level `const`

### Log panel UX (vdovhanych's request for a larger/more navigable log viewer)
- Replace 6 inline filter buttons with a single **multi-select "Filters" dropdown** with checkboxes and tooltips; selection persisted in localStorage
- **Fullscreen expand** button (icon) — grows the log card to fill the full canvas height alongside the VNC viewer
- **Side panel** button (icon) — moves the log panel to the left of the VNC viewer, all four panels visible simultaneously; only shown on wide screens (>1280px)
- **Drag-to-resize** handle between VNC viewer and bottom log panel (vertical drag)
- **Drag-to-resize** handle between log panel and VNC viewer in side mode (horizontal drag)
- All resize dimensions persisted in localStorage
- Fix tooltip clipping on log card header buttons
- Align Trezor logo and "Emulator" text vertically in topbar

## Test plan
- [ ] Start emulator, verify log entries appear and filter dropdown works (multi-select)
- [ ] Uncheck some filters, reload — confirm selection is restored
- [ ] Click expand icon — log card grows to fill canvas height; click again to collapse
- [ ] On wide screen (>1280px): click side panel icon — log moves left of VNC; drag handle resizes; click again to return
- [ ] Drag the horizontal handle between VNC and bottom log — height adjusts and persists on reload
- [ ] Hover toolbar buttons (Filters, Clear, expand, side) — tooltips appear above buttons
- [ ] Start T3W1 emulator — Tropic starts; stop emulator — Tropic also stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)