### PR TITLE
fix(emulator): fall back to UDP when bridge device enumeration times out

### DIFF
--- a/src/emulator.py
+++ b/src/emulator.py
@@ -121,7 +121,13 @@ def wait_for_udp_device() -> Transport:
 def get_device() -> Transport:
     # Node bridges need UDP
     if bridge.is_running() and not bridge.is_node_bridge_running():
-        return wait_for_bridge_device()
+        try:
+            return wait_for_bridge_device()
+        except RuntimeError:
+            log(
+                "Bridge is running but device not found via bridge, falling back to UDP",
+                "yellow",
+            )
 
     return wait_for_udp_device()
 


### PR DESCRIPTION
## Summary

- `bridge.is_running()` returns `True` as soon as port 21325 is bound, but the bridge may not yet have enumerated the emulator device
- Previously `get_device()` would call `wait_for_bridge_device()`, exhaust the 15s timeout, and raise — leaving the emulator stuck and unreachable
- Now, if bridge enumeration times out, `get_device()` logs a warning and falls back to `wait_for_udp_device()` so the device stays reachable

## Root cause

The scenario that triggers the bug:
1. User starts emulator (works fine via UDP)
2. User starts bridge — port 21325 binds almost immediately, `is_running()` → `True`
3. Any subsequent operation calls `get_device()`, which now takes the bridge path
4. Bridge hasn't finished enumerating the emulator yet → `get_bridge_device()` returns nothing → 15s timeout → exception

## Test plan

- [ ] Start emulator, then start bridge — emulator should remain responsive immediately
- [ ] Normal flow (bridge first, then emulator) still works unchanged
- [ ] Node bridge path is unaffected (bypasses the bridge path entirely)

🤖 Generated with [Claude Code](https://claude.com/claude-code)