### PR TITLE
Fix Custom FW emulator isRunning detection

### DIFF
--- a/src/emulator.py
+++ b/src/emulator.py
@@ -127,6 +127,15 @@ def get_device() -> Transport:
 
 
 def is_running() -> bool:
+    # Prefer the tracked process handle — it works regardless of the binary
+    # name, which matters for custom firmware downloads whose file names may
+    # not contain the "trezor-emu" substring.
+    if EMULATOR is not None and EMULATOR.process is not None:
+        if EMULATOR.process.poll() is None:
+            return True
+
+    # Fallback: scan the process table for any emulator instance that we
+    # did not spawn ourselves (e.g. started before the controller).
     # Need to use special flags, as just `ps -ef` truncates the lines to 80 chars
     check_cmd = "ps -eo pid,ppid,args"
     process = Popen(check_cmd, shell=True, stdout=PIPE, stderr=PIPE)


### PR DESCRIPTION
When you run a custom FW, it did not detect is as a running process.

resolves https://github.com/trezor/trezor-user-env/issues/367

**Tested with the following steps**:
**Happy paths**
  - Start emulator with default firmware — verify sidebar turns green, VNC iframe appears
  - Start emulator with custom firmware from URL — verify sidebar turns green, VNC iframe appears
  - Start emulator with custom firmware from branch — verify sidebar turns green, VNC iframe appears
  - Stop any running emulator — verify sidebar turns red, VNC iframe disappears

  **Edge cases**
  - Start custom FW, then switch to default FW — verify status transitions correctly
  - Start custom FW, then start different custom FW — verify old one stops, new one shows running
  - Start custom FW, kill the process externally (kill <pid>) — verify sidebar turns red via background polling