### PR TITLE
fix(dashboard): toggle sidebar flyout closed on repeated button click

### DIFF
--- a/src/dashboard/js/index.js
+++ b/src/dashboard/js/index.js
@@ -837,7 +837,7 @@ const app = createApp({
                     });
                 });
             } else {
-                this.openFly = id;
+                this.openFly = this.openFly === id ? null : id;
             }
         },
         closeFlyouts() {


### PR DESCRIPTION
I was really triggered when I click again on the button that opens the panel but does not close it.

So I changed it.

https://github.com/user-attachments/assets/76cb6700-60b7-4557-a42b-08bd44636e7d

