### PR TITLE
fix: add sdl3 to nix dependencies

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation {
     autoPatchelfHook
     python311
     uv
+    sdl3
+    sdl3-image
     SDL2
     SDL2_image
     xorg.xhost

--- a/src/binaries/firmware/bin/patch-emulators-nix.sh
+++ b/src/binaries/firmware/bin/patch-emulators-nix.sh
@@ -44,14 +44,22 @@ SDL2=$(dirname "$SDL2_LIB" 2>/dev/null || echo "")
 SDL2_IMG_LIB=$(ls /nix/store/*SDL2*image*/lib/libSDL2_image-2.0.so.0 2>/dev/null | head -1)
 SDL2_IMG=$(dirname "$SDL2_IMG_LIB" 2>/dev/null || echo "")
 
+SDL3_LIB=$(ls /nix/store/*sdl3-*/lib/libSDL3.so.0 2>/dev/null | head -1)
+SDL3=$(dirname "$SDL3_LIB" 2>/dev/null || echo "")
+
+SDL3_IMG_LIB=$(ls /nix/store/*sdl3-*/lib/libSDL3_image.so.0 2>/dev/null | head -1)
+SDL3_IMG=$(dirname "$SDL3_IMG_LIB" 2>/dev/null || echo "")
+
 INTERPRETER=$(patchelf --print-interpreter $(which python) 2>/dev/null || echo "")
 GLIBC=$(dirname "$INTERPRETER" 2>/dev/null || echo "")
 
-if [ -z "$LIBJPEG" ] || [ -z "$SDL2" ] || [ -z "$SDL2_IMG" ] || [ -z "$GLIBC" ] || [ -z "$INTERPRETER" ]; then
+if [[ -z "$LIBJPEG" || -z "$SDL2" || -z "$SDL2_IMG" || -z "$SDL3" || -z "$SDL3_IMG" || -z "$GLIBC" || -z "$INTERPRETER" ]]; then
     echo "ERROR: Could not find required libraries in Nix store"
     echo "LIBJPEG: $LIBJPEG"
     echo "SDL2: $SDL2"
     echo "SDL2_IMG: $SDL2_IMG"
+    echo "SDL3: $SDL3"
+    echo "SDL3_IMG: $SDL3_IMG"
     echo "GLIBC: $GLIBC"
     echo "INTERPRETER: $INTERPRETER"
     exit 1
@@ -60,12 +68,14 @@ fi
 echo "  ✓ libjpeg:     $LIBJPEG"
 echo "  ✓ SDL2:        $SDL2"
 echo "  ✓ SDL2_image:  $SDL2_IMG"
+echo "  ✓ SDL3:        $SDL3"
+echo "  ✓ SDL3_image:  $SDL3_IMG"
 echo "  ✓ glibc:       $GLIBC"
 echo "  ✓ interpreter: $INTERPRETER"
 echo ""
 
 # Step 2: Build new rpath
-NEW_RPATH="$LIBJPEG:$SDL2:$SDL2_IMG:$GLIBC"
+NEW_RPATH="$LIBJPEG:$SDL2:$SDL2_IMG:$SDL3:$SDL3_IMG:$GLIBC"
 
 # Step 3: Patch all emulator binaries
 echo "Step 2: Patching emulator binaries..."


### PR DESCRIPTION
emulators `*-main` require `sdl3` and `sdl3-image` libs

```
ldd ./src/binaries/firmware/bin/trezor-emu-core-T3B1-v2-main 
	linux-vdso.so.1 (0x00007a6ddb8c2000)
	libm.so.6 => /nix/store/776irwlgfb65a782cxmyk61pck460fs9-glibc-2.40-66/lib/libm.so.6 (0x00007a6ddb7d2000)
	libjpeg.so.62 => /nix/store/ld48pvj263k06rvljmh8la69ghh11yy0-libjpeg-turbo-3.1.1/lib/libjpeg.so.62 (0x00007a6dd8d33000)
	libSDL3_image.so.0 => not found
	libSDL3.so.0 => not found
	libc.so.6 => /nix/store/776irwlgfb65a782cxmyk61pck460fs9-glibc-2.40-66/lib/libc.so.6 (0x00007a6dd8a00000)
	/nix/store/776irwlgfb65a782cxmyk61pck460fs9-glibc-2.40-66/lib/ld-linux-x86-64.so.2 => /nix/store/776irwlgfb65a782cxmyk61pck460fs9-glibc-2.40-66/lib64/ld-linux-x86-64.so.2 (0x00007a6ddb8c4000)


ldd ./src/binaries/firmware/bin/trezor-emu-core-T3W1-v2-main
	linux-vdso.so.1 (0x00007e00750af000)
	libm.so.6 => /nix/store/776irwlgfb65a782cxmyk61pck460fs9-glibc-2.40-66/lib/libm.so.6 (0x00007e0072318000)
	libjpeg.so.62 => not found
	libSDL3_image.so.0 => not found
	libSDL3.so.0 => not found
	libc.so.6 => /nix/store/776irwlgfb65a782cxmyk61pck460fs9-glibc-2.40-66/lib/libc.so.6 (0x00007e0072000000)
	/nix/store/l0l2ll1lmylczj1ihqn351af2kyp5x19-glibc-2.42-51/lib/ld-linux-x86-64.so.2 => /nix/store/776irwlgfb65a782cxmyk61pck460fs9-glibc-2.40-66/lib64/ld-linux-x86-64.so.2 (0x00007e00750b1000)

```
