### PR TITLE
Prevent uv from using packages newer than 30 days

### DIFF
--- a/docker/Dockerfile-debian
+++ b/docker/Dockerfile-debian
@@ -42,7 +42,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install uv for package management
-COPY --from=ghcr.io/astral-sh/uv:0.8.20 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.15 /uv /uvx /bin/
 
 # Copy project configuration files
 WORKDIR /trezor-user-env

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,6 @@ packages = ["src"]
 
 [tool.mypy]
 exclude = "^trezor-suite/"
+
+[tool.uv]
+exclude-newer = "30 days"

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,7 @@
 let
-  # the last commit from master as of 2025-09-23
-  nixpkgsCommit = "7ea43b194fff615fe75741cf258988d6571623e0";
-  nixpkgsSha256 = "09nbk2q4w3v8x3v4r2y2s7v3nk8n4wqzxgykkp7na9bhijry2zla";
+  # the last commit from master as of 2026-03-15
+  nixpkgsCommit = "a07d4ce6bee67d7c838a8a5796e75dff9caa21ef";
+  nixpkgsSha256 = "0f6zni3jn6ji5icwbidbpmcgxdal2qnjszp7ragdcy0857hvq3c5";
 
   nixpkgsUrl = "https://github.com/NixOS/nixpkgs/archive/${nixpkgsCommit}.tar.gz";
 
@@ -23,17 +23,17 @@ stdenv.mkDerivation {
   name = "trezor-user-env-controller";
   buildInputs = [
     autoPatchelfHook
-    python311
+    python312
     uv
     sdl3
     sdl3-image
     SDL2
     SDL2_image
-    xorg.xhost
-    xorg.xorgserver # Xvfb
+    xhost
+    xorg-server # Xvfb
     x11vnc
     xdotool
-    python311Packages.websockify
+    python312Packages.websockify
     wget
     git
     curl

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,10 @@ resolution-markers = [
     "python_full_version < '3.13'",
 ]
 
+[options]
+exclude-newer = "2026-04-15T14:04:42.102685295Z"
+exclude-newer-span = "P30D"
+
 [[package]]
 name = "atomicwrites"
 version = "1.4.1"


### PR DESCRIPTION
 - Limits exposure of the repo to supply chain compromise -- as long as you use uv.
 - If it is necessary to break this rule and install a "young" package, it is necessary to whitelist the package -- use `exclude-newer-package` (https://docs.astral.sh/uv/reference/settings/#exclude-newer-package).

Note: To be able to use relative duration with `uv`, it was necessary to update `nixpkgs` in `shell.nix`. This has a side effect - nix now uses python 3.12 instead of python 3.11.

Note2: This check was implemented in trezor-firmware repo in [PR #6919](https://github.com/trezor/trezor-firmware/pull/6919), in trezor-definitions here: https://github.com/trezor/definitions/pull/54, more repos to come...