### PR TITLE
fix: nodebridge bin import patch

### DIFF
--- a/src/binaries/node-bridge/modify_node_bin_js.sh
+++ b/src/binaries/node-bridge/modify_node_bin_js.sh
@@ -11,7 +11,7 @@ if [ ! -f "$1" ]; then
 fi
 
 # Getting rid of USB import, which is not needed when we will spawn in with UDP argument
-string_to_comment='^var import_usb ='
+string_to_comment='^var import_usb[0-9]* ='
 if grep -q "$string_to_comment" "$1"; then
   sed -i "/$string_to_comment/ s/^/\/\//" "$1"
   echo "Success: line matching '$string_to_comment' was commented out."


### PR DESCRIPTION
Suite PR https://github.com/trezor/trezor-suite/pull/27297 made some changes to the node bridge `bin.js`, causing `var import_usb` to change to `var import_usb2`

This line is being patched on user-env side, so we need to adjust the regex to match accordingly

Passing build: https://github.com/trezor/trezor-user-env/actions/runs/26165950764/job/76970016515