### PR TITLE
feat(dashboard): warn that legacy trezord-go bridge is unsupported

### DIFF
--- a/src/dashboard/css/index.css
+++ b/src/dashboard/css/index.css
@@ -1685,6 +1685,28 @@ label[data-tooltip]:hover::before {
 }
 .vlist-divider::after { content: ""; flex: 1; height: 1px; background: var(--border); }
 
+.bridge-legacy-warning {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 8px 10px;
+    margin: 4px 0 6px;
+    border: 1px solid var(--amber);
+    border-radius: 8px;
+    background: var(--amber-soft);
+    color: var(--amber);
+    font-size: 11.5px;
+    line-height: 1.45;
+}
+.bridge-legacy-warning svg { width: 14px; height: 14px; flex-shrink: 0; margin-top: 1px; }
+.bridge-legacy-warning b { font-weight: 600; }
+.bridge-legacy-warning code {
+    font-size: 11px;
+    padding: 1px 4px;
+    border-radius: 4px;
+    background: rgba(0, 0, 0, .08);
+}
+
 .vgroup { margin-top: 10px; }
 .vgroup:first-child { margin-top: 0; }
 .vgroup-head {

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -678,6 +678,17 @@
                             <span v-if="bridges.statusColor === 'green' && bridges.selected === v" class="vitem-badge">running</span>
                         </button>
                         <div v-if="modernBridgeVersions.length && legacyBridgeVersions.length" class="vlist-divider">legacy</div>
+                        <div v-if="legacyBridgeVersions.length" class="bridge-legacy-warning">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                                <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
+                                <line x1="12" y1="9" x2="12" y2="13"/>
+                                <line x1="12" y1="17" x2="12.01" y2="17"/>
+                            </svg>
+                            <span>
+                                <b>Legacy <code>trezord-go</code> bridge is no longer supported by Trezor Suite.</b>
+                                Use <code>node-bridge</code> above; only keep legacy for testing against older Suite versions.
+                            </span>
+                        </div>
                         <button
                             v-for="v in legacyBridgeVersions"
                             :key="v"


### PR DESCRIPTION
## Summary

- Adds an amber warning banner above the legacy 2.x (`trezord-go`) bridge entries in the Bridge flyout.
- Modern `node-bridge` remains the only version supported by Trezor Suite. Legacy bridges are kept available, but the UI now makes their deprecated status explicit.

## Preview

![Legacy bridge warning — dark and light theme](https://github.com/mroz22/scrape-issues/releases/download/pr-385-preview/legacy-bridge-warning.png)

## Rationale

We want to keep legacy `trezord-go` available for a while (e.g. testing against older Suite versions), but signal clearly that it should not be used for normal workflows. This PR is the short-term step.

The follow-up PR that removes `trezord-go` entirely is **#386** — merge this one first, then land #386 once we are comfortable retiring legacy completely.

## Test plan

- [ ] Open the dashboard, expand the Bridge flyout
- [ ] Verify the amber warning appears above the `2.0.33` / `2.0.32` entries
- [ ] Verify the warning is hidden when no legacy bridges are listed (e.g. on macOS)
- [ ] Verify dark/light themes both render the banner readably