### PR TITLE
fix(legacy): use correct model when opening DebugLink

### DIFF
--- a/src/emulator.py
+++ b/src/emulator.py
@@ -470,6 +470,9 @@ def connect_to_debuglink(
         client = DebugLink(get_device().find_debug())
 
     client.open()
+    if client.model is None:
+        client.model = models.by_internal_name(MODEL_RUNNING)
+
     time.sleep(SLEEP)
 
     try:


### PR DESCRIPTION
Otherwise, it will send `DebugLinkGetState` to T1B1: https://github.com/trezor/trezor-firmware/blob/7ee61f3a38d8afe7ecce7697690b89dfd1ae27cb/python/src/trezorlib/debuglink.py#L819

Currently, T1B1 may overwrite `DebugLinkGetDecision` by a consecutive `DebugLinkGetState` message (due to tiny mode limitation), so we would like to avoid sending `DebugLinkGetState` after each `DebugLinkGetDecision` (as done for Core FW).

[no changelog]