### PR TITLE
[WIP, SLOP] Align native Nix setup with Docker emulator prep

### DIFF
--- a/run-nix.sh
+++ b/run-nix.sh
@@ -1,13 +1,26 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 DIR=$(dirname "$0")
 cd "${DIR}"
 
 SYSTEM_ARCH=$(uname -m)
+
+echo "Preparing firmware emulator binaries"
+RELEASE_MINOR_LIMIT=5 nix-shell --run "uv run python src/binaries/firmware/bin/download.py releases"
+nix-shell --run "uv run python src/binaries/firmware/bin/download.py nightly"
+
 if [[ $SYSTEM_ARCH == aarch64* ]]; then
     # Patch trezord after the container starts to prevent flaky behavior with arm version.
-    nix-shell -p bash --run "cd ./src/binaries/trezord-go/bin/ && ./download.sh"
+    nix-shell --run "cd ./src/binaries/trezord-go/bin/ && ./download.sh"
 fi
 
+echo "Preparing node bridge"
+nix-shell --run "./src/binaries/node-bridge/download.sh"
+
+echo "Patching firmware emulator binaries for Nix"
+nix-shell --run "./src/binaries/firmware/bin/patch-bin.sh ./src/binaries/firmware/bin"
+
 echo "Starting trezor-user-env server"
-nix-shell --run "uv run python src/main.py"
+nix-shell --run "PYTHONUNBUFFERED=1 uv run python src/main.py"

--- a/shell.nix
+++ b/shell.nix
@@ -17,12 +17,23 @@ let
     rev = "v1.5.0";
     sha256 = "sha256-3Q87bYsC824/8A85Kxdqlm+InuuR/D/HjVrYTJZfE9Y=";
   };
+
+  emulatorRuntimeLibs = with pkgs; [
+    stdenv.cc.cc
+    zlib
+    libjpeg
+    sdl3
+    sdl3-image
+    SDL2
+    SDL2_image
+  ];
 in
 with pkgs;
 stdenv.mkDerivation {
   name = "trezor-user-env-controller";
   buildInputs = [
     autoPatchelfHook
+    bash
     python312
     uv
     sdl3
@@ -41,6 +52,8 @@ stdenv.mkDerivation {
     procps
   ];
   shellHook = ''
+    export TREZOR_USER_ENV_AUTO_PATCHELF_LIBS="${lib.makeLibraryPath emulatorRuntimeLibs}"
+
     # Build a writable noVNC web root with our custom viewer
     NOVNC_LOCAL="$PWD/.novnc"
     if [ ! -d "$NOVNC_LOCAL/core" ]; then

--- a/src/binaries/firmware/bin/patch-bin.sh
+++ b/src/binaries/firmware/bin/patch-bin.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SYSTEM_ARCH=$(uname -m)
 echo "System architecture: $SYSTEM_ARCH"
@@ -8,7 +8,17 @@ BINARY_DIR="${1:-./}"
 
 # ./src/binaries/firmware/bin/patch-bin.sh ./src/binaries/firmware/bin/
 if [ -n "$IN_NIX_SHELL" ]; then
-    nix-shell --run "autoPatchelf ${BINARY_DIR}trezor-emu-*"
+    mapfile -t EMULATORS < <(find "$BINARY_DIR" -type f -name 'trezor-emu-*' -executable | sort)
+    if [ "${#EMULATORS[@]}" -eq 0 ]; then
+        echo "No emulator binaries found under $BINARY_DIR"
+        exit 0
+    fi
+    if [ -n "${TREZOR_USER_ENV_AUTO_PATCHELF_LIBS:-}" ]; then
+        IFS=: read -r -a NIX_LIB_DIRS <<< "$TREZOR_USER_ENV_AUTO_PATCHELF_LIBS"
+    else
+        mapfile -t NIX_LIB_DIRS < <(find /nix/store -maxdepth 2 -type d -name lib 2>/dev/null | sort)
+    fi
+    auto-patchelf --ignore-missing --paths "${EMULATORS[@]}" --libs "${NIX_LIB_DIRS[@]}"
     exit
 fi
 

--- a/src/binaries/node-bridge/modify_node_bin_js.sh
+++ b/src/binaries/node-bridge/modify_node_bin_js.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -z "$1" ]; then
   echo "Please supply the path to the file to modify"


### PR DESCRIPTION
## Summary

- Make `run-nix.sh` prepare native Nix runs similarly to Docker:
  - download release emulator binaries
  - download current main/nightly emulator binaries
  - prepare node-bridge
  - patch emulator binaries for Nix before starting the controller
- Limit release emulator downloads to the latest 5 release artifacts per model.
- Keep current main/nightly emulator per model available.
- Fix Nix execution issues in shell scripts:
  - avoid `/bin/bash` shebang assumptions
  - avoid nested `nix-shell` from `patch-bin.sh`
  - call `auto-patchelf` with explicit runtime library paths

## Verification

- `python -m py_compile src/binaries/firmware/bin/download.py`
- `RELEASE_MINOR_LIMIT=5 nix-shell --run "uv run python src/binaries/firmware/bin/download.py releases"`
- `nix-shell --run "uv run python src/binaries/firmware/bin/download.py nightly"`
- `nix-shell --run "./src/binaries/firmware/bin/patch-bin.sh ./src/binaries/firmware/bin"`
- Firmware scanner output confirmed:
  - `T1B1`: main + 5 releases
  - `T2T1`: main + 5 releases
  - `T3B1`: main + 5 releases
  - `T3T1`: main + 5 releases
  - `T3W1`: main + 4 releases currently available from source

## Notes

- T3W1 currently resolves to main + 4 release artifacts because only 4 release artifacts were available from the source.
- Existing local `src/mcp/uv.lock` changes were intentionally left out of this commit.
