### PR TITLE
feat(dashboard): install custom firmware from an uploaded binary file

### DIFF
--- a/docs/controller.md
+++ b/docs/controller.md
@@ -52,6 +52,17 @@
     - **output_to_logfile**: `bool` (default=True) whether the debug output should go to a logfile - otherwise it goes to stdout
     - **save_screenshots**: `bool` (default=False) whether to save screenshots to enable calling **emulator-get-screenshot**
 
+- **emulator-start-from-file**
+  - **action**: saves an uploaded emulator binary and runs it
+  - **note**: the profile is always wiped for an uploaded binary, since reusing a name overwrites the previous binary and a stale profile must not be run against a different build
+  - **arguments**:
+    - **file**: `str` base64-encoded contents of the emulator binary
+    - **filename**: `str` (default="uploaded") original file name, used to derive the stored emulator name
+    - **model**: `str` which emulator it is - `["T1B1", "T2T1", "T3B1", "T3T1", "T3W1"]`
+    - **output_to_logfile**: `bool` (default=True) whether the debug output should go to a logfile - otherwise it goes to stdout
+    - **save_screenshots**: `bool` (default=False) whether to save screenshots to enable calling **emulator-get-screenshot**
+    - **show_animations**: `bool` (default=False) whether to show device animations
+
 - **emulator-stop**
   - **action**: stop the emulator
 

--- a/src/controller.py
+++ b/src/controller.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import base64
+import binascii
 import json
 import os
 import traceback
@@ -42,6 +44,10 @@ if TYPE_CHECKING:
 IP = "0.0.0.0"
 PORT = 9001
 LOG_COLOR = "blue"
+# Max size of an incoming WebSocket message (bytes). The default is 1 MiB,
+# which is too small for uploaded firmware binaries; 256 MiB gives plenty of
+# headroom for the base64-encoded payload.
+MAX_WS_MESSAGE_SIZE = 256 * 1024 * 1024
 REGTEST_RPC = BTCJsonRPC(
     url=os.getenv("REGTEST_RPC_URL") or "http://0.0.0.0:18021",
     user="rpc",
@@ -93,7 +99,13 @@ class ResponseGetter:
         self.request_id = self.request_dict.get("id", "unknown")
 
         if self.command != "background-check":
-            log(f"Request: {self.request_dict}")
+            # Avoid dumping large binary uploads (base64 firmware) into the log.
+            if "file" in self.request_dict:
+                loggable = dict(self.request_dict)
+                loggable["file"] = f"<{len(self.request_dict['file'])} base64 chars>"
+                log(f"Request: {loggable}")
+            else:
+                log(f"Request: {self.request_dict}")
 
         try:
             command_response = self.run_command_and_get_its_response()
@@ -277,6 +289,49 @@ class ResponseGetter:
                 show_animations=show_animations,
             )
             response_text = f"Emulator downloaded from branch {branch} and started"
+            if wipe:
+                response_text += " and wiped to be empty"
+            return {"response": response_text, "emulator_started": True}
+        elif self.command == "emulator-start-from-file":
+            model = self.request_dict["model"]
+            if not model:
+                return {
+                    "success": False,
+                    "error": "Model must be supplied for the emulator to start",
+                }
+            # NOTE: model is validated inside emulator.start_from_file().
+            file_b64 = self.request_dict.get("file")
+            if not file_b64:
+                return {
+                    "success": False,
+                    "error": "File content must be supplied for the emulator to start",
+                }
+            try:
+                file_bytes = base64.b64decode(file_b64, validate=True)
+            except (binascii.Error, ValueError) as e:
+                return {
+                    "success": False,
+                    "error": f"Invalid file content, expected base64: {repr(e)}",
+                }
+            filename = self.request_dict.get("filename") or "uploaded"
+            output_to_logfile = self.request_dict.get("output_to_logfile", True)
+            save_screenshots = self.request_dict.get("save_screenshots", False)
+            show_animations = self.request_dict.get("show_animations", False)
+            # An uploaded binary reusing an existing name silently overwrites the
+            # old one, so a stale profile could otherwise be run against a
+            # different build. Always start a file upload from a clean profile.
+            wipe = True
+            PREV_RUNNING_MODEL = model
+            emulator.start_from_file(
+                file_bytes=file_bytes,
+                filename=filename,
+                model=model,
+                wipe=wipe,
+                output_to_logfile=output_to_logfile,
+                save_screenshots=save_screenshots,
+                show_animations=show_animations,
+            )
+            response_text = f"Emulator loaded from uploaded file {filename} and started"
             if wipe:
                 response_text += " and wiped to be empty"
             return {"response": response_text, "emulator_started": True}
@@ -486,7 +541,9 @@ async def handler(websocket, path) -> None:
 def start() -> None:
     log(f"Starting websocket server (controller.py) at {IP}:{PORT}")
 
-    server = serve(handler, IP, PORT)
+    # Allow large messages so custom firmware binaries can be uploaded over
+    # the WebSocket (base64-encoded, so ~33% larger than the raw file).
+    server = serve(handler, IP, PORT, max_size=MAX_WS_MESSAGE_SIZE)
 
     asyncio.get_event_loop().run_until_complete(server)
     asyncio.get_event_loop().run_forever()

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -582,7 +582,7 @@
                     >
                         <svg class="disclosure-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="9 6 15 12 9 18"/></svg>
                         <span>Custom firmware</span>
-                        <span class="disclosure-note">URL or branch build (overrides model &amp; firmware above)</span>
+                        <span class="disclosure-note">URL, branch or file build (overrides model &amp; firmware above)</span>
                     </button>
 
                     <div v-if="customFirmwareOpen" class="disclosure-body">
@@ -599,6 +599,12 @@
                                 :class="{ 'segmented-on': customFirmwareSource === 'branch' }"
                                 @click="customFirmwareSource = 'branch'"
                             >From branch</button>
+                            <button
+                                type="button"
+                                role="tab"
+                                :class="{ 'segmented-on': customFirmwareSource === 'file' }"
+                                @click="customFirmwareSource = 'file'"
+                            >From file</button>
                         </div>
 
                         <div v-if="customFirmwareSource === 'url'" class="custom-src">
@@ -614,7 +620,7 @@
                             </button>
                         </div>
 
-                        <div v-else class="custom-src">
+                        <div v-else-if="customFirmwareSource === 'branch'" class="custom-src">
                             <input class="input" type="text" placeholder="e.g. feature/new-ui" v-model="emulatorBranch.branch" />
                             <select class="select" v-model="emulatorBranch.model">
                                 <option value="" disabled>Model…</option>
@@ -628,6 +634,20 @@
                             </label>
                             <button class="btn btn--full" @click="emulatorStartFromBranch()">
                                 Launch from branch
+                            </button>
+                        </div>
+
+                        <div v-else class="custom-src">
+                            <input class="input" type="file" @change="onFirmwareFileSelected" />
+                            <span class="disclosure-note">Upload an emulator build (e.g. trezor-emu-core-&lt;MODEL&gt;-universal), not a flashable firmware .bin</span>
+                            <select class="select" v-model="emulatorFile.model">
+                                <option value="" disabled>Model…</option>
+                                <option v-for="(details, model) in emulators.versions" :key="model" :value="model">
+                                    {{ details.header }} ({{ model }})
+                                </option>
+                            </select>
+                            <button class="btn btn--full" @click="emulatorStartFromFile()">
+                                Launch from file
                             </button>
                         </div>
                     </div>

--- a/src/dashboard/js/index.js
+++ b/src/dashboard/js/index.js
@@ -83,6 +83,11 @@ const app = createApp({
                 model: "",
                 btcOnly: false,
             },
+            emulatorFile: {
+                fileName: "",
+                fileContent: "",
+                model: "",
+            },
             emulatorDownloadMessage: "",
             customFirmwareSource: "url",
             customFirmwareOpen: false,
@@ -334,7 +339,8 @@ const app = createApp({
             if (
                 "response" in dataObject &&
                 typeof dataObject.response === 'string' &&
-                dataObject.response.includes("Emulator downloaded")
+                (dataObject.response.includes("Emulator downloaded") ||
+                    dataObject.response.includes("Emulator loaded from uploaded file"))
             ) {
                 this.emulatorDownloadMessage = "";
             }
@@ -391,7 +397,11 @@ const app = createApp({
                 return;
             }
 
-            this.logEvent(`Request sent: ${JSON.stringify(msg)}`, "var(--blue)");
+            // Avoid dumping large binary uploads (base64 firmware) into the log.
+            const msgForLog = msg.file
+                ? Object.assign({}, msg, { file: `<${msg.file.length} base64 chars>` })
+                : msg;
+            this.logEvent(`Request sent: ${JSON.stringify(msgForLog)}`, "var(--blue)");
 
             const requestToSend = JSON.stringify(
                 Object.assign(msg, {
@@ -542,6 +552,56 @@ const app = createApp({
 
             this.emulatorDownloadMessage =
                 "Emulator started downloading, it may take a while...";
+            this.closeFlyouts();
+        },
+        onFirmwareFileSelected(event) {
+            const file = event.target.files && event.target.files[0];
+            if (!file) {
+                this.emulatorFile.fileName = "";
+                this.emulatorFile.fileContent = "";
+                return;
+            }
+            this.emulatorFile.fileName = file.name;
+            this.emulatorFile.fileContent = "";
+            const reader = new FileReader();
+            reader.onload = () => {
+                // reader.result is a data URL: "data:...;base64,<content>"
+                const result = reader.result;
+                const commaIndex = result.indexOf(",");
+                this.emulatorFile.fileContent =
+                    commaIndex >= 0 ? result.slice(commaIndex + 1) : result;
+            };
+            reader.onerror = () => {
+                this.showNotification("Failed to read the selected file!", true);
+            };
+            reader.readAsDataURL(file);
+        },
+        emulatorStartFromFile() {
+            const fileName = this.emulatorFile.fileName;
+            const fileContent = this.emulatorFile.fileContent;
+            if (!fileName || !fileContent) {
+                this.showNotification("No firmware file selected!", true);
+                return;
+            }
+
+            const model = this.emulatorFile.model;
+            if (!model) {
+                this.showNotification("Model is empty!", true);
+                return;
+            }
+
+            this.sendMessage({
+                type: "emulator-start-from-file",
+                filename: fileName,
+                file: fileContent,
+                model,
+                output_to_logfile: this.emulators.outputToLogfile,
+                save_screenshots: this.emulators.screenshotMode,
+                show_animations: this.emulators.animations,
+            });
+
+            this.emulatorDownloadMessage =
+                "Uploading firmware and starting emulator, it may take a while...";
             this.closeFlyouts();
         },
         reflectBackgroundSituationInGUI(dataObject) {

--- a/src/emulator.py
+++ b/src/emulator.py
@@ -160,6 +160,33 @@ def get_url_identifier(url: str) -> str:
     return url.replace("/", "-").replace(":", "-")
 
 
+def detect_file_kind(file_bytes: bytes) -> str:
+    """Best-effort identification of an uploaded file from its magic bytes,
+    so validation errors can tell the user what they actually uploaded."""
+    head = file_bytes[:8]
+    signatures = [
+        (b"\x7fELF", "ELF executable"),
+        (b"TRZV", "Trezor device firmware image (.bin)"),
+        (b"\x1f\x8b", "gzip archive (.gz)"),
+        (b"PK\x03\x04", "zip archive (.zip)"),
+        (b"\xfd7zXZ\x00", "xz archive (.xz)"),
+        (b"BZh", "bzip2 archive (.bz2)"),
+        (b"MZ", "Windows executable (.exe/PE)"),
+        (b"\xcf\xfa\xed\xfe", "macOS executable (Mach-O)"),
+        (b"\xca\xfe\xba\xbe", "macOS executable (Mach-O fat)"),
+        (b"%PDF", "PDF document"),
+    ]
+    for magic, name in signatures:
+        if head.startswith(magic):
+            return name
+    stripped = head.lstrip().lower()
+    if stripped.startswith((b"<!do", b"<htm", b"<?xml")):
+        return "HTML/XML text (likely an error page)"
+    if not file_bytes:
+        return "empty file"
+    return f"unknown (first bytes: {file_bytes[:8].hex(' ')})"
+
+
 def start_from_url(
     url: str,
     model: binaries.Model,
@@ -267,6 +294,67 @@ def start_from_branch(
         save_screenshots=save_screenshots,
         force_update=True,
         force_name=force_name,
+        show_animations=show_animations,
+    )
+
+
+def start_from_file(
+    file_bytes: bytes,
+    filename: str,
+    model: binaries.Model,
+    wipe: bool,
+    output_to_logfile: bool = True,
+    save_screenshots: bool = False,
+    show_animations: bool = False,
+) -> None:
+    binaries.check_model(model)
+
+    # The emulator is a native Linux executable (an "emu build", ELF), not a
+    # flashable device firmware image nor an archive. Reject the wrong artifact
+    # early with a clear message (naming the detected format) instead of a
+    # cryptic "Exec format error" at launch time.
+    if file_bytes[:4] != b"\x7fELF":
+        detected = detect_file_kind(file_bytes)
+        raise RuntimeError(
+            f"Uploaded file is not a Linux executable (missing ELF header); "
+            f"detected: {detected}. The emulator must be a native emu build, "
+            f"e.g. trezor-emu-core-<MODEL>-universal from "
+            f"data.trezor.io/dev/firmware/ - not a flashable firmware .bin, "
+            f"an archive, or an HTML/error page. If it is compressed "
+            f"(.gz/.zip/.xz), decompress it first, then upload the raw binary."
+        )
+
+    # Deriving a stable emulator name from the uploaded file name, so it can be
+    # reused (and shows up nicely in the registry). Uploads always overwrite.
+    safe_name = re.sub(r"[^A-Za-z0-9._-]", "-", filename).strip("-") or "uploaded"
+    emu_name = f"{model}-file-{safe_name}"
+    if binaries.IS_ARM and not emu_name.endswith(binaries.ARM_IDENTIFIER):
+        emu_name = f"{emu_name}{binaries.ARM_IDENTIFIER}"
+
+    # Deciding the location to save depending on the model
+    # (to be compatible with already existing emulators)
+    model_identifier = binaries.MODEL_IDENTIFIERS.get(model)
+    if not model_identifier:
+        raise RuntimeError(f"Unknown model {model}")
+    emu_path = binaries.USER_DOWNLOADED_DIR / f"{model_identifier}{emu_name}"
+
+    log(f"Uploaded emulator ({len(file_bytes)} bytes) will be saved under {emu_path}")
+    emu_path.write_bytes(file_bytes)
+
+    # Running chmod +x on the newly saved emulator and patching it so it can
+    # run in Nix (patching fail will not cause any python error, so there will
+    # be no problems even for machines without Nix)
+    emu_path.chmod(emu_path.stat().st_mode | stat.S_IEXEC)
+    binaries.patch_emulators_for_nix(str(binaries.USER_DOWNLOADED_DIR))
+    # Registering the new emulator so we know its location
+    binaries.register_new_firmware(model, emu_name, str(emu_path))
+
+    return start(
+        version=emu_name,
+        model=model,
+        wipe=wipe,
+        output_to_logfile=output_to_logfile,
+        save_screenshots=save_screenshots,
         show_animations=show_animations,
     )
 


### PR DESCRIPTION
## What

Adds a **"From file"** option to the Custom firmware panel in the dashboard, alongside the existing **From URL** and **From branch** flows. You can now upload an emulator build directly instead of pointing at a URL or branch.

## How it works

- The selected file is base64-encoded in the browser and sent over the existing websocket as a new `emulator-start-from-file` command.
- The backend decodes it, writes it to `user_downloaded/`, makes it executable + patches it for Nix, registers it, and launches it — reusing the same tail as `start_from_url`/`start_from_branch`.

## Notable details

- **Validation:** rejects non-ELF artifacts early and names the detected format (e.g. a `TRZV` device firmware `.bin`, a gzip/zip archive, or an HTML error page), instead of failing later with a cryptic `Exec format error`.
- **Always wipes:** a re-upload reusing the same name overwrites the previous binary, so the profile is always wiped to avoid running a stale profile against a different build.
- **Websocket max message size** raised to 256 MiB so firmware binaries fit (default was 1 MiB).
- **Log hygiene:** the base64 blob is redacted from both the client and server request logs.
- **Docs:** `docs/controller.md` documents the new command.

## Testing

- `py_compile` / `node --check` pass.
- Manually exercised the upload flow in the local Docker dashboard; confirmed the validation path (rejecting a `TRZV` firmware image and a non-ELF file with clear messages).
- Not yet verified end-to-end with a real ARM emu build launching — draft pending that check.