### PR TITLE
feat(emulator): reboot running emulator into bootloader mode

### DIFF
--- a/docs/controller.md
+++ b/docs/controller.md
@@ -116,6 +116,9 @@
 - **emulator-wipe**
   - **action**: wipe the emulator
 
+- **emulator-reboot-to-bootloader**
+  - **action**: reboot a running (firmware) emulator into bootloader mode (core models only - T2T1/T3B1/T3T1/T3W1; requires a running emulator)
+
 - **emulator-apply-settings**
   - **action**: apply settings on emulator
   - **arguments**:

--- a/src/controller.py
+++ b/src/controller.py
@@ -349,6 +349,9 @@ class ResponseGetter:
         elif self.command == "emulator-wipe":
             emulator.wipe_device()
             return {"response": "Device wiped"}
+        elif self.command == "emulator-reboot-to-bootloader":
+            emulator.reboot_to_bootloader()
+            return {"response": "Emulator rebooted to bootloader"}
         elif self.command == "emulator-apply-settings":
             # Relaying all the relevant fields from the request, to make sure
             #   the client is notified when it sends an unknown field

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -340,6 +340,7 @@
                                         <button class="cmd-btn" @click="emulatorResetDevice()" data-tooltip="Initializes a new wallet on the emulator (standard single-seed setup)">Reset</button>
                                         <button class="cmd-btn" @click="emulatorResetDeviceShamir()" data-tooltip="Initializes a new wallet using Shamir Secret Sharing backup" data-tooltip-pos="right">Reset w/ Shamir</button>
                                     </div>
+                                    <button class="cmd-btn" style="width:100%;margin-top:6px" @click="emulatorRebootToBootloader()" data-tooltip="Reboots a running emulator into bootloader mode (core models only)">Reboot to bootloader</button>
                                 </div>
 
                                 <!-- §9.3 Verify & debug -->

--- a/src/dashboard/js/index.js
+++ b/src/dashboard/js/index.js
@@ -663,6 +663,11 @@ const app = createApp({
                 type: "emulator-wipe",
             });
         },
+        emulatorRebootToBootloader() {
+            this.sendMessage({
+                type: "emulator-reboot-to-bootloader",
+            });
+        },
         emulatorResetDevice() {
             this.sendMessage({
                 type: "emulator-reset-device",

--- a/src/emulator.py
+++ b/src/emulator.py
@@ -524,6 +524,23 @@ def wipe_device() -> None:
         device.wipe(client.get_seedless_session())
 
 
+def reboot_to_bootloader() -> None:
+    """Reboot a running (firmware) emulator into bootloader mode.
+
+    Requires a running emulator and only works for core models
+    (T2T1/T3B1/T3T1/T3W1); the legacy T1B1 emulator is not supported. The
+    emulator re-execs on reboot, so the debug/transport connection is expected
+    to drop right after the command is accepted - that is not a failure.
+    """
+    if not VERSION_RUNNING:
+        raise RuntimeError("No emulator running.")
+    if MODEL_RUNNING == "T1B1":
+        raise RuntimeError("Reboot to bootloader is not supported on T1B1.")
+
+    with connect_to_client() as client:
+        device.reboot_to_bootloader(client.get_seedless_session())
+
+
 def reset_device(
     backup_type: messages.BackupType, strength: int, use_shamir: bool = False
 ) -> None:


### PR DESCRIPTION
## What

Adds an `emulator-reboot-to-bootloader` controller command (plus a dashboard button) that reboots a **running** firmware emulator into the emulated **bootloader** mode.

## How it works

- Uses `trezorlib.device.reboot_to_bootloader(session, boot_command=STOP_AND_WAIT)` — the same mechanism firmware/bootloader flows are tested with against the emulator.
- `emulator.reboot_to_bootloader()` mirrors the existing `wipe_device()` client pattern (`connect_to_client()` → `get_seedless_session()`).
- Dashboard: a "Reboot to bootloader" button in the *Setup — lifecycle* section.

## Constraints / guards

- **Requires a running emulator** — this reboots *from* firmware *into* bootloader; it is not a cold boot straight into the bootloader.
- **Core models only** (T2T1/T3B1/T3T1/T3W1). Guarded against no-emulator-running and against T1B1 (legacy).

## ⚠️ Untested — draft

I have **not** run this against a live emulator yet. Two things to verify before marking ready:
1. That the standalone `trezor-emu-core` builds from `data.trezor.io` actually reboot into a waiting bootloader on `RebootToBootloader` (vs. exiting).
2. **Connection teardown:** `connect_to_client()`'s `finally` calls `watch_layout(False)`; since the emulator re-execs on reboot, that teardown (or a follow-up reconnect) may raise as the transport drops. If so, we should swallow the expected post-reboot disconnect. Left as-is for now to keep the diff minimal and matching `wipe_device()`.

## Why

Groundwork toward flashing real device firmware images (`TRZV` `.bin`) onto the emulator, which requires bootloader mode + `trezorlib.firmware.update()`. Complements the separate "custom firmware from an uploaded emulator binary" PR (#393), but is independent of it (based directly on `master`).