### PR TITLE
fix: remove xhost from build inputs and enforce X11 for SDL in VNC setup

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -29,7 +29,6 @@ stdenv.mkDerivation {
     sdl3-image
     SDL2
     SDL2_image
-    xhost
     xorg-server # Xvfb
     x11vnc
     xdotool

--- a/src/vnc.py
+++ b/src/vnc.py
@@ -173,4 +173,7 @@ def setup_env() -> None:
     """Set environment variables for VNC display mode."""
     os.environ["DISPLAY"] = DISPLAY
     os.environ["SDL_VIDEO_WINDOW_POS"] = "0,0"
+    # Force X11 — with WAYLAND_DISPLAY set, SDL would open the emulator window on the host desktop instead of the Xvfb display.
+    os.environ.pop("WAYLAND_DISPLAY", None)
+    os.environ["SDL_VIDEODRIVER"] = "x11"
     _log(f"Using VNC display {DISPLAY}")


### PR DESCRIPTION
Fix emulator window escaping to the host desktop on Wayland

When running natively on a Wayland desktop, SDL prefers the Wayland driver over X11, so the emulator window opened on the host desktop instead of the Xvfb display captured by VNC. Strip WAYLAND_DISPLAY and force SDL_VIDEODRIVER=x11 before spawning the emulator, and drop the now-unused xhost package from shell.nix.