### PR TITLE
Feat: nightly fw versions from binary

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
       - name: "Install dependencies with uv"
         run: nix-shell --run "uv sync"
       - name: "Download emulator binaries"
-        run: nix-shell --run "uv run python ./src/binaries/firmware/bin/download.py all"
+        run: nix-shell --run "PYTHONPATH=./src uv run python ./src/binaries/firmware/bin/download.py all"
       - name: "Download node bridge"
         run: nix-shell --run "./src/binaries/node-bridge/download.sh"
       - name: "Patch emulator binaries"

--- a/docker/Dockerfile-debian
+++ b/docker/Dockerfile-debian
@@ -56,6 +56,7 @@ RUN uv sync
 # Copy firmware downloader scripts separately so release emulator downloads can stay cached
 RUN mkdir -p /trezor-user-env/src/binaries/firmware/bin
 COPY ./src/binaries/firmware/bin/ /trezor-user-env/src/binaries/firmware/bin/
+COPY ./src/nightly_versions.py /trezor-user-env/src/nightly_versions.py
 RUN uv run python ./src/binaries/firmware/bin/download.py releases
 
 # Copy the rest of the files

--- a/src/binaries/firmware/bin/download.py
+++ b/src/binaries/firmware/bin/download.py
@@ -6,10 +6,19 @@ import platform
 import shutil
 import stat
 import subprocess
+import sys
 import tempfile
 import urllib.error
 import urllib.request
 from pathlib import Path
+
+# When executed directly, python only adds this nested bin/ directory to
+# sys.path, so prepend the src/ root to import nightly_versions.py shared helper
+ROOT_DIR = Path(__file__).resolve().parents[3]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from nightly_versions import write_nightly_versions_metadata
 
 BASE_EMU_URL = "https://data.trezor.io/dev/firmware/releases/emulators-new"
 NIGHTLY_BASE_URL = "https://data.trezor.io/dev/firmware/emu-nightly"
@@ -161,6 +170,8 @@ def download_nightly(bin_dir: Path, nightly_files: list[tuple[str, str]]) -> Non
             downloaded_path = tmp_dir_path / source_name
             download_file(source_url, downloaded_path, required=True)
             shutil.move(downloaded_path, bin_dir / destination_name)
+
+    write_nightly_versions_metadata(bin_dir)
 
 
 def postprocess(bin_dir: Path) -> None:

--- a/src/controller.py
+++ b/src/controller.py
@@ -17,6 +17,7 @@ import emulator
 import helpers
 import tropic_model
 from bitcoin_regtest.rpc import BTCJsonRPC
+from nightly_versions import read_nightly_versions_metadata
 
 if TYPE_CHECKING:
     from typing_extensions import TypedDict
@@ -70,6 +71,10 @@ def _normalize_emulator_version(version: str) -> str:
     if normalized.endswith("-arm"):
         normalized = normalized[: -len("-arm")]
     return normalized
+
+
+def get_nightly_versions() -> dict[str, str]:
+    return read_nightly_versions_metadata(binaries.FIRMWARE_BIN_DIR)
 
 
 class ResponseGetter:
@@ -558,6 +563,7 @@ async def welcome(websocket) -> None:
         "type": "client",
         "id": "TODO",
         "firmwares": binaries.get_all_firmware_versions(),
+        "nightly_versions": get_nightly_versions(),
         "bridges": binaries.BRIDGES,
     }
     await websocket.send(json.dumps(intro))

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -107,7 +107,7 @@
                         <svg class="sb-item-icon" viewBox="0 0 24 24"><rect x="5" y="2" width="14" height="20" rx="3"/><line x1="10" y1="18" x2="14" y2="18"/></svg>
                         <span class="sb-item-text">
                             <span class="sb-item-label">Emulator</span>
-                            <span v-if="emulators.runningVersion" class="sb-item-version">{{ emulators.runningVersion }}</span>
+                            <span v-if="emulators.runningVersion" class="sb-item-version">{{ formatFirmwareLabel(emulators.runningModel, emulators.runningVersion) }}</span>
                         </span>
                         <span
                             :class="[
@@ -549,7 +549,7 @@
                             v-for="option in emulators.versions[selectedEmulatorModel].versions"
                             :key="option"
                             :value="option"
-                        >{{ option }}</option>
+                        >{{ formatFirmwareLabel(selectedEmulatorModel, option) }}</option>
                     </select>
 
                     <label class="field-label">

--- a/src/dashboard/js/index.js
+++ b/src/dashboard/js/index.js
@@ -36,6 +36,7 @@ const app = createApp({
                 runningVersion: null,
             },
             selectedEmulatorModel: store.get('userEnvSelectedModel', 'T3W1'),
+            nightlyFirmwareVersions: {},
             emulators: {
                 versions: {
                     T1B1: {
@@ -349,6 +350,7 @@ const app = createApp({
 
             // Filling the possible options for the emulators/bridges
             if (dataObject.type === "client") {
+                this.nightlyFirmwareVersions = dataObject.nightly_versions || {};
                 for (const model in dataObject.firmwares) {
                     const options = dataObject.firmwares[model];
                     this.emulators.versions[model].versions = options;
@@ -487,6 +489,16 @@ const app = createApp({
             });
             // If the flyout is open, close it so the user sees the device stage come to life.
             if (this.openFly === 'flyEmu') this.closeFlyouts();
+        },
+        formatFirmwareLabel(model, version) {
+            if (typeof version !== 'string') return version;
+
+            let nightlyVersion;
+            if (version.match(/^([0-9]+)-main/)) {
+                nightlyVersion = this.nightlyFirmwareVersions[model];
+            }
+
+            return nightlyVersion ? `${version} (${nightlyVersion})` : version;
         },
         emulatorStartFromUrl() {
             const url = this.emulatorUrl.url;

--- a/src/nightly_versions.py
+++ b/src/nightly_versions.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def _metadata_file(bin_dir: Path) -> Path:
+    return bin_dir / "nightly-versions.json"
+
+
+def _read_u32_le(data: bytes, offset: int) -> int | None:
+    if offset < 0 or offset + 4 > len(data):
+        return None
+    return int.from_bytes(data[offset : offset + 4], "little")
+
+
+def _version_from_trzf_header(data: bytes, offset: int) -> str | None:
+    # TRZF firmware header has fixed 1024-byte size and version bytes at 0x10-0x12.
+    if offset < 0 or offset + 1024 > len(data):
+        return None
+    if data[offset : offset + 4] != b"TRZF":
+        return None
+
+    hdrlen = _read_u32_le(data, offset + 0x04)
+    codelen = _read_u32_le(data, offset + 0x0C)
+    if hdrlen != 1024 or codelen is None or codelen <= 0:
+        return None
+
+    end_of_image = offset + hdrlen + codelen
+    if end_of_image > len(data):
+        return None
+
+    major = data[offset + 0x10]
+    minor = data[offset + 0x11]
+    patch = data[offset + 0x12]
+    return f"{major}.{minor}.{patch}"
+
+
+def _version_from_core_binary(data: bytes) -> str | None:
+    # Core firmware image starts with TRZV vendor header followed by TRZF.
+    search_from = 0
+    while True:
+        vendor_offset = data.find(b"TRZV", search_from)
+        if vendor_offset == -1:
+            return None
+
+        vendor_hdrlen = _read_u32_le(data, vendor_offset + 0x04)
+        if vendor_hdrlen is not None and vendor_hdrlen > 0:
+            trzf_offset = vendor_offset + vendor_hdrlen
+            version = _version_from_trzf_header(data, trzf_offset)
+            if version is not None:
+                return version
+
+        search_from = vendor_offset + 1
+
+
+def _version_from_legacy_binary(data: bytes) -> str | None:
+    # Legacy images may be TRZR (256-byte header) + TRZF (v2 header).
+    search_from = 0
+    while True:
+        legacy_offset = data.find(b"TRZR", search_from)
+        if legacy_offset == -1:
+            break
+
+        version = _version_from_trzf_header(data, legacy_offset + 256)
+        if version is not None:
+            return version
+
+        search_from = legacy_offset + 1
+
+    return None
+
+
+def _read_nightly_binary(bin_dir: Path, prefix: str) -> bytes | None:
+    direct = bin_dir / prefix
+    if direct.is_file():
+        try:
+            return direct.read_bytes()
+        except OSError:
+            pass
+
+    # ARM nightly names currently append -arm suffix.
+    candidates = sorted(bin_dir.glob(f"{prefix}*"))
+    for candidate in candidates:
+        if candidate.is_file():
+            try:
+                return candidate.read_bytes()
+            except OSError:
+                continue
+
+    return None
+
+
+def write_nightly_versions_metadata(bin_dir: Path) -> dict[str, str]:
+    parsed: dict[str, str] = {}
+    nightly_binaries = {
+        "T1B1": (
+            "trezor-emu-legacy-T1B1-v1-main",
+            _version_from_legacy_binary,
+        ),
+        "T2T1": ("trezor-emu-core-T2T1-v2-main", _version_from_core_binary),
+        "T3B1": ("trezor-emu-core-T3B1-v2-main", _version_from_core_binary),
+        "T3T1": ("trezor-emu-core-T3T1-v2-main", _version_from_core_binary),
+        "T3W1": ("trezor-emu-core-T3W1-v2-main", _version_from_core_binary),
+    }
+
+    for name, (prefix, parser) in nightly_binaries.items():
+        data = _read_nightly_binary(bin_dir, prefix)
+        if data is None:
+            continue
+
+        version = parser(data)
+        if version is not None:
+            parsed[name] = version
+
+    metadata = read_nightly_versions_metadata(bin_dir)
+    metadata.update(parsed)
+
+    destination = _metadata_file(bin_dir)
+    with destination.open("w", encoding="utf-8") as f:
+        json.dump(metadata, f, indent=2, sort_keys=True)
+        f.write("\n")
+    return metadata
+
+
+def read_nightly_versions_metadata(bin_dir: Path) -> dict[str, str]:
+    metadata_path = _metadata_file(bin_dir)
+    if not metadata_path.is_file():
+        return {}
+
+    try:
+        with metadata_path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception:
+        return {}
+
+    if not isinstance(data, dict):
+        return {}
+
+    versions: dict[str, str] = {}
+    for key in ("T1B1", "T2T1", "T3B1", "T3T1", "T3W1"):
+        value = data.get(key)
+        if isinstance(value, str):
+            versions[key] = value
+
+    return versions

--- a/tests/nightly_versions_test.py
+++ b/tests/nightly_versions_test.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Make src/nightly_versions.py importable when running tests from repo root.
+ROOT_DIR = Path(__file__).resolve().parent.parent
+SRC_DIR = ROOT_DIR / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+import nightly_versions as nv
+
+
+def _build_trzf_image(major: int, minor: int, patch: int, codelen: int = 16) -> bytes:
+    header = bytearray(1024)
+    header[0:4] = b"TRZF"
+    header[0x04:0x08] = (1024).to_bytes(4, "little")
+    header[0x0C:0x10] = codelen.to_bytes(4, "little")
+    header[0x10] = major
+    header[0x11] = minor
+    header[0x12] = patch
+    return bytes(header) + (b"\xaa" * codelen)
+
+
+def test_version_from_trzf_header_valid() -> None:
+    image = _build_trzf_image(2, 13, 7)
+    assert nv._version_from_trzf_header(image, 0) == "2.13.7"
+
+
+def test_version_from_trzf_header_wrong_magic() -> None:
+    image = bytearray(_build_trzf_image(2, 13, 7))
+    image[0:4] = b"ABCD"
+    assert nv._version_from_trzf_header(bytes(image), 0) is None
+
+
+def test_version_from_trzf_header_truncated() -> None:
+    # Less than 1024 bytes cannot contain a valid TRZF header.
+    truncated = b"TRZF" + b"\x00" * 100
+    assert nv._version_from_trzf_header(truncated, 0) is None
+
+
+def test_version_from_core_binary_valid() -> None:
+    vendor_header_len = 512
+    vendor = bytearray(vendor_header_len)
+    vendor[0:4] = b"TRZV"
+    vendor[0x04:0x08] = vendor_header_len.to_bytes(4, "little")
+    blob = b"\x00" * 33 + bytes(vendor) + _build_trzf_image(2, 12, 3)
+
+    assert nv._version_from_core_binary(blob) == "2.12.3"
+
+
+def test_version_from_core_binary_invalid_layout() -> None:
+    # TRZV exists, but hdrlen points past the blob, so parsing must fail.
+    vendor = bytearray(64)
+    vendor[0:4] = b"TRZV"
+    vendor[0x04:0x08] = (10_000).to_bytes(4, "little")
+    blob = bytes(vendor) + _build_trzf_image(2, 12, 3)
+
+    assert nv._version_from_core_binary(blob) is None
+
+
+def test_version_from_legacy_binary_valid() -> None:
+    legacy = bytearray(256)
+    legacy[0:4] = b"TRZR"
+    blob = bytes(legacy) + _build_trzf_image(1, 14, 2)
+
+    assert nv._version_from_legacy_binary(blob) == "1.14.2"
+
+
+def test_version_from_legacy_binary_wrong_magic() -> None:
+    blob = b"XXXX" + (b"\x00" * 252) + _build_trzf_image(1, 14, 2)
+    assert nv._version_from_legacy_binary(blob) is None
+
+
+def test_read_nightly_binary_falls_back_when_direct_unreadable(
+    tmp_path, monkeypatch
+) -> None:
+    prefix = "trezor-emu-core-T2T1-v2-main"
+    direct = tmp_path / prefix
+    fallback = tmp_path / f"{prefix}-arm"
+    direct.write_bytes(b"direct")
+    fallback.write_bytes(b"fallback")
+
+    original_read_bytes = Path.read_bytes
+
+    def fake_read_bytes(path: Path) -> bytes:
+        if path == direct:
+            raise OSError("simulated direct read error")
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", fake_read_bytes)
+
+    assert nv._read_nightly_binary(tmp_path, prefix) == b"fallback"
+
+
+def test_read_nightly_binary_continues_after_candidate_error(
+    tmp_path, monkeypatch
+) -> None:
+    prefix = "trezor-emu-core-T3W1-v2-main"
+    bad_candidate = tmp_path / f"{prefix}-a"
+    good_candidate = tmp_path / f"{prefix}-b"
+    bad_candidate.write_bytes(b"bad")
+    good_candidate.write_bytes(b"good")
+
+    original_read_bytes = Path.read_bytes
+
+    def fake_read_bytes(path: Path) -> bytes:
+        if path == bad_candidate:
+            raise OSError("simulated candidate read error")
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", fake_read_bytes)
+
+    assert nv._read_nightly_binary(tmp_path, prefix) == b"good"


### PR DESCRIPTION
Different approach for https://github.com/trezor/trezor-user-env/pull/398

Read nightly FW version directly from binary file instead of reading the version from firmware repo source files