### PR TITLE
fix(emulator): nightly ARM emulator URL

### DIFF
--- a/src/emulator.py
+++ b/src/emulator.py
@@ -242,7 +242,7 @@ def start_from_branch(
 ) -> None:
     emu_name = "trezor-emu-core"
     if binaries.IS_ARM:
-        emu_name += binaries.ARM_IDENTIFIER
+        emu_name = f"trezor-emu-{binaries.ARM_IDENTIFIER}-core"
     emu_name += f"-{model}"
     if btc_only:
         emu_name += "-btconly"


### PR DESCRIPTION
The filename part of URLs to download nightly emulators for ARM are slightly different between `src/emulator.py` and `src/binaries/firmware/bin/download.py`:

* [download.py](https://github.com/trezor/trezor-user-env/blob/8d3416fa8cfbbbac97266b8742741437ee1719bf/src/binaries/firmware/bin/download.py#L44): `trezor-emu-arm-core-T2T1-universal` (good)
* [emulator.py](https://github.com/trezor/trezor-user-env/blob/8d3416fa8cfbbbac97266b8742741437ee1719bf/src/emulator.py#L234): `trezor-emu-core-arm-T2T1-universal` (bad)

Makes me think starting an emulator from `main` branch isn't working on ARM unless you pull new docker image where it's pre-downloaded. I haven't actually tested it.

Context: for the past ~month we've been uploading emulators to the "bad" URL trezor/trezor-firmware#7411 so ARM docker images had outdated nightly. We can change the naming convention to something else if it helps.