### PR TITLE
fix(emulator): use branch-specific ARM emulator name

### DIFF
--- a/src/emulator.py
+++ b/src/emulator.py
@@ -240,9 +240,15 @@ def start_from_branch(
     save_screenshots: bool = False,
     show_animations: bool = False,
 ) -> None:
-    emu_name = "trezor-emu-core"
-    if binaries.IS_ARM:
-        emu_name = f"trezor-emu-{binaries.ARM_IDENTIFIER}-core"
+    # The nightly and per-branch pipelines name their ARM builds differently:
+    # nightly uses "trezor-emu-arm-core-*", branches use "trezor-emu-core-arm-*".
+    is_nightly = branch == "main"
+    if binaries.IS_ARM and is_nightly:
+        emu_name = f"trezor-emu{binaries.ARM_IDENTIFIER}-core"
+    elif binaries.IS_ARM:
+        emu_name = f"trezor-emu-core{binaries.ARM_IDENTIFIER}"
+    else:
+        emu_name = "trezor-emu-core"
     emu_name += f"-{model}"
     if btc_only:
         emu_name += "-btconly"
@@ -250,7 +256,7 @@ def start_from_branch(
         emu_name += "-universal"
 
     # Main has just a nightly pipeline
-    if branch == "main":
+    if is_nightly:
         url = f"https://data.trezor.io/dev/firmware/emu-nightly/{emu_name}"
     else:
         url = f"https://data.trezor.io/dev/firmware/emu-branches/{branch}/{emu_name}"


### PR DESCRIPTION
## What

`start_from_branch` now picks the ARM emulator filename per pipeline instead of using one name for all branches.

The nightly and per-branch firmware pipelines name their ARM builds differently:

| pipeline | ARM filename |
|---|---|
| nightly (`main`) | `trezor-emu-arm-core-<model>-universal` |
| branch builds | `trezor-emu-core-arm-<model>-universal` |

## Bug / cause

Commit 7ad5442 fixed the nightly ARM URL but applied the nightly name (`trezor-emu-arm-core-*`) to branch builds too. On Apple Silicon every branch load then requested `trezor-emu-arm-core-<model>-universal`, which does not exist for branch pipelines, 404'd, and fell back to the mangled `...-universal-arm`. Observed as:

```
HTTP error ... trezor-emu--arm-core-T3T1-universal-arm, <HTTPError 404>
```

The fix selects `trezor-emu-arm-core-*` for `main` (nightly) and `trezor-emu-core-arm-*` for branches, restoring the pre-7ad5442 branch form.

## Validation

Generated names verified against the server (all HTTP 200):

- nightly ARM → `trezor-emu-arm-core-T3T1-universal`
- nightly x86 → `trezor-emu-core-T3T1-universal`
- branch ARM → `trezor-emu-core-arm-T3T1-universal` (e.g. branch `romanz/2608/fix-payreq-mac`)
- branch x86 → `trezor-emu-core-T3T1-universal`

x86 path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)